### PR TITLE
feat(pre-generate-images): add option to pre generate images to store in zip file of pdf cropper

### DIFF
--- a/components/Cbt/Interface/CbtInterfaceQuestionPanel.vue
+++ b/components/Cbt/Interface/CbtInterfaceQuestionPanel.vue
@@ -34,7 +34,7 @@ const props = defineProps<{
   isQuestionPalleteCollapsed: boolean
 }>()
 
-const { testQuestionsData, currentTestState, testSectionsImgUrls, lastLoggedAnswer } = useCbtTestData()
+const { testQuestionsData, currentTestState, testQuestionsUrls, lastLoggedAnswer } = useCbtTestData()
 
 const { uiSettings } = useCbtSettings()
 
@@ -48,10 +48,9 @@ const questionImgMaxSize = computed(() => {
 })
 
 const currentQuestionImgUrls = computed(() => {
-  const section = currentTestState.value.section
-  const question = currentTestState.value.question
+  const queId = currentTestState.value.queId
 
-  const questionImgs = testSectionsImgUrls.value?.[section]?.[question]
+  const questionImgs = testQuestionsUrls.value?.[queId]
   if (questionImgs) {
     return questionImgs
   }

--- a/components/GenerateTestImages.vue
+++ b/components/GenerateTestImages.vue
@@ -38,13 +38,11 @@ const props = defineProps<{
   questionImgScale: number
   devicePixelRatio?: number
   cropperSectionsData: CropperSectionsData
-  isImagesForPdfCropper?: boolean
 }>()
 
 const emit = defineEmits<{
   imageBlobsGenerated: [testImageBlobs: TestImageBlobs]
   currentQuestionProgress: [questionNum: number]
-  doneGenerating: []
 }>()
 
 const mupdfOgWorker = new mupdfWorkerFile()
@@ -120,26 +118,7 @@ async function generateQuestionImages() {
 
   mupdfWorker.close()
 
-  if (props.isImagesForPdfCropper) {
-    emit('imageBlobsGenerated', questionsBlobs)
-  }
-  else {
-    const { testSectionsImgUrls } = useCbtTestData()
-
-    for (const [section, sectionData] of Object.entries(questionsBlobs)) {
-      testSectionsImgUrls.value[section] = {}
-
-      for (const [question, blobs] of Object.entries(sectionData)) {
-        testSectionsImgUrls.value[section][question] ??= []
-
-        for (const blob of blobs) {
-          const url = URL.createObjectURL(blob)
-          testSectionsImgUrls.value[section][question].push(url)
-        }
-      }
-    }
-    emit('doneGenerating')
-  }
+  emit('imageBlobsGenerated', questionsBlobs)
 }
 
 onBeforeUnmount(() => {

--- a/components/PdfCropper/PdfCropperQuestionDetailsPanel.vue
+++ b/components/PdfCropper/PdfCropperQuestionDetailsPanel.vue
@@ -12,9 +12,10 @@
       >
         <InputText
           id="subject_name"
-          v-model.trim="currentQuestionData.subjectName"
+          v-model="currentQuestionData.subjectName"
           :maxlength="30"
           :disabled="!isPdfLoaded"
+          @blur="() => currentQuestionData.subjectName = currentQuestionData.subjectName.trim()"
         />
       </BaseFloatLabel>
       <span class="flex items-center justify-center grow border-l border-surface-700 bg-surface-900 text-surface-300">
@@ -28,9 +29,10 @@
       >
         <InputText
           id="section_name"
-          v-model.trim="currentQuestionData.sectionName"
+          v-model="currentQuestionData.sectionName"
           :maxlength="40"
           :disabled="!isPdfLoaded"
+          @blur="() => currentQuestionData.sectionName = currentQuestionData.sectionName.trim()"
         />
       </BaseFloatLabel>
       <span class="flex items-center justify-center grow border-l border-surface-700 bg-surface-900 text-surface-300">

--- a/composables/useCbtResultsTestQuestionsImgUrls.ts
+++ b/composables/useCbtResultsTestQuestionsImgUrls.ts
@@ -1,9 +1,8 @@
+import type { QuestionsImageUrls } from '~/src/types'
 import { CbtUseState } from '~/src/types/enums'
 
 type ResultsTestQuestionsImgUrls = {
-  [testId: number | string]: {
-    [queId: number | string]: string[]
-  }
+  [testId: number | string]: QuestionsImageUrls
 }
 
 export default () => {

--- a/composables/useCbtTestData.ts
+++ b/composables/useCbtTestData.ts
@@ -8,7 +8,7 @@ import type {
   TestSectionKey,
   TestQuestionData,
   QuestionStatus,
-  TestSectionsImgUrls,
+  QuestionsImageUrls,
 } from '~/src/types'
 import { CbtUseState } from '~/src/types/enums'
 
@@ -153,7 +153,7 @@ export default () => {
     },
   )
 
-  const testSectionsImgUrls = useState<TestSectionsImgUrls>(
+  const testQuestionsUrls = useState<QuestionsImageUrls>(
     CbtUseState.TestSectionsImgUrls,
     () => ({}),
   )
@@ -170,7 +170,7 @@ export default () => {
     testSectionsData,
     testQuestionsData,
     lastLoggedAnswer,
-    testSectionsImgUrls,
+    testQuestionsUrls,
     testSectionsSummary,
   }
 }

--- a/pages/cbt/generate-answer-key.vue
+++ b/pages/cbt/generate-answer-key.vue
@@ -70,12 +70,11 @@
       <CbtFileUpload
         v-model="fileUploaderState.selectedFileType"
         :file-options="selectOptions.fileUploader"
-        :validation-function="fileUploaderValidationFunction"
         file-types="zip-or-json"
         empty-slot-text-class="top-[35%]"
         root-class="sm:w-4/5 md:w-3/4 lg:w-2/3 mx-auto"
         content-class="min-h-48 md:min-h-64"
-        @on-uploaded="(data) => loadFileData(data.jsonData, data.pdfFile)"
+        @uploaded="(data) => loadFileData(data.jsonData, data.pdfFile)"
       />
     </div>
     <div

--- a/pages/cbt/generate-answer-key.vue
+++ b/pages/cbt/generate-answer-key.vue
@@ -67,14 +67,12 @@
       <h3 class="text-xl text-center">
         You can load either zip/json file of PDF Cropper or json file of CBT Interface/Results
       </h3>
-      <CbtFileUpload
-        v-model="fileUploaderState.selectedFileType"
-        :file-options="selectOptions.fileUploader"
-        file-types="zip-or-json"
-        empty-slot-text-class="top-[35%]"
-        root-class="sm:w-4/5 md:w-3/4 lg:w-2/3 mx-auto"
-        content-class="min-h-48 md:min-h-64"
-        @uploaded="(data) => loadFileData(data.jsonData, data.pdfFile)"
+      <BaseSimpleFileUpload
+        accept="application/json,application/zip,.json,.zip"
+        :label="'Select ZIP/JSON File'"
+        invalid-file-type-message="Invalid file. Please select a valid ZIP or JSON file from PDF Cropper Page"
+        icon-name="prime:plus"
+        @upload="handleFileUpload"
       />
     </div>
     <div
@@ -346,11 +344,6 @@ import { DataFileNames } from '~/src/types/enums'
 
 type UnknownRecord = Record<string, unknown>
 
-type FileUploaderData = {
-  pdfFile: Uint8Array | null
-  jsonData: Record<string, unknown>
-}
-
 type SectionListItem = TestSectionListItem & { totalQuestions: number }
 
 type QuestionAnswerKeyData = {
@@ -373,21 +366,6 @@ interface DBTestOutputDataState {
   isDataFromDB: boolean
 }
 
-// if yes then load that and this below will be storing it
-const dbTestOutputDataState = shallowReactive<DBTestOutputDataState>({
-  isDataFound: false, // boolean to indicate if testResultOverviews without results generated is found or not
-  testResultOverviews: [], // list of testResultOverviews without results generated
-  selectedTestResultOverviewIndex: null,
-  isDataFromDB: false, // is data that is loaded (or being used) from db?
-})
-
-// if data to generate from is not found in db then
-// ask user to upload file of cropper/interface/results, this will store the fileUploader related data
-const fileUploaderState = shallowReactive({
-  selectedFileType: 'json',
-  isFileLoaded: false,
-})
-
 const tooltipContent = {
   questionsNumberingOrderType:
     'Select how question numbers appear in the "Q. Num" Column. This is for visual use only (internally all questions are referred by original Q. Num):\n\n'
@@ -404,8 +382,25 @@ const tooltipContent = {
 
 const INPUT_ID_PREFIX = 'input-answer-q-'
 
-// to store raw uploaded file data
-const uploadedFileData = shallowRef<FileUploaderData | null>(null)
+// if yes then load that and this below will be storing it
+const dbTestOutputDataState = shallowReactive<DBTestOutputDataState>({
+  isDataFound: false, // boolean to indicate if testResultOverviews without results generated is found or not
+  testResultOverviews: [], // list of testResultOverviews without results generated
+  selectedTestResultOverviewIndex: null,
+  isDataFromDB: false, // is data that is loaded (or being used) from db?
+})
+
+// if data to generate from is not found in db then
+// ask user to upload file of cropper/interface/results, this will store the fileUploader related data
+const fileUploaderState = shallowReactive<{
+  isFileLoaded: boolean
+  unzippedFiles: AsyncZippable | null
+  jsonData: Record<string, unknown> | null
+}>({
+  isFileLoaded: false,
+  unzippedFiles: null,
+  jsonData: null,
+})
 
 const selectOptions = {
   questionsNumberingOrder: [
@@ -413,24 +408,6 @@ const selectOptions = {
     { name: 'Cumulative', value: 'cumulative' },
     { name: 'Section-wise', value: 'section-wise' },
   ],
-
-  fileUploader: [
-    { name: 'ZIP', value: 'zip' },
-    { name: 'JSON', value: 'json' },
-  ],
-}
-
-const fileUploaderValidationFunction = (data: FileUploaderData): Promise<boolean> => {
-  return new Promise((resolve, reject) => {
-    const status = Boolean(data.jsonData?.pdfCropperData || data.jsonData.testData)
-
-    if (status) {
-      resolve(true)
-    }
-    else {
-      reject('JSON File is not in valid format, are you sure you had selected correct file?')
-    }
-  })
 }
 
 const settingsState = shallowReactive({
@@ -470,10 +447,8 @@ const outputFileTypeOptions = computed(() => {
     { name: '.json (separate)', value: 'json-separate' },
   ]
 
-  if (uploadedFileData.value) {
-    if (uploadedFileData.value.pdfFile && fileUploaderState.selectedFileType === 'zip') {
-      return options
-    }
+  if (fileUploaderState.unzippedFiles) {
+    return options
   }
 
   if (dbTestOutputDataState.isDataFromDB) {
@@ -707,21 +682,19 @@ function getQuestionOptions(questionData: CropperQuestionData | TestOutputDataQu
   return 4
 }
 
-function loadFileData(
-  jsonData: UnknownRecord,
-  pdfFile: Uint8Array | null,
-) {
-  if (jsonData.testData) {
-    subjectsData = jsonData.testData as TestOutputDataSubjects
+function loadFileData() {
+  const jsonData = fileUploaderState.jsonData
+  if (jsonData?.testData) {
+    subjectsData = jsonData.testData as TestOutputDataSubjects ?? null
   }
-  else if (jsonData.testOutputDatas) {
+  else if (jsonData?.testOutputDatas) {
     const testOutputData = (jsonData.testOutputDatas as Record<string, unknown>[])[0]
     if (testOutputData.testData) {
-      subjectsData = testOutputData.testData as TestOutputDataSubjects
+      subjectsData = testOutputData.testData as TestOutputDataSubjects ?? null
     }
   }
   else {
-    subjectsData = jsonData.pdfCropperData as CropperOutputData
+    subjectsData = jsonData?.pdfCropperData as CropperOutputData ?? null
   }
 
   if (subjectsData === null) {
@@ -729,21 +702,34 @@ function loadFileData(
     return
   }
 
-  if (pdfFile && fileUploaderState.selectedFileType === 'zip') {
+  if (fileUploaderState.unzippedFiles) {
     generateOutputState.selectedFileType = 'zip'
   }
 
-  loadDataState(jsonData, pdfFile)
+  loadDataState()
 }
 
-function loadDataState(
-  jsonData: UnknownRecord,
-  pdfFile: Uint8Array | null,
-) {
-  uploadedFileData.value = {
-    pdfFile,
-    jsonData,
+async function handleFileUpload(files: File | File[]) {
+  try {
+    const file = Array.isArray(files) ? files[0] : files
+    const zipFileCheckStatus = await utilIsZipFile(file)
+    if (zipFileCheckStatus > 0) {
+      const { jsonData, unzippedFiles } = await utilUnzipTestDataFile(file, 'json-only', true)
+      fileUploaderState.jsonData = jsonData
+      fileUploaderState.unzippedFiles = unzippedFiles ?? null
+    }
+    else {
+      fileUploaderState.jsonData = await utilParseJsonFile(file)
+    }
+
+    loadFileData()
   }
+  catch (err) {
+    console.error('Error while handling file upload', err)
+  }
+}
+
+function loadDataState() {
   if (!subjectsData) return
 
   for (const [subject, sectionData] of Object.entries(subjectsData)) {
@@ -792,29 +778,28 @@ function generateAnswerKey() {
 }
 
 async function downloadOutput() {
-  if (!uploadedFileData.value) return
+  const selectedFileType = generateOutputState.selectedFileType
+  if (selectedFileType != 'json-separate' && !fileUploaderState.jsonData) return
 
   generateOutputState.preparingDownload = true
   if (Object.keys(testAnswerKeyData).length === 0) {
     generateAnswerKey()
   }
 
-  const uploadedData = toValue(uploadedFileData)!
-
-  uploadedData.jsonData.testAnswerKey = testAnswerKeyData
-
   const filename = generateOutputState.filename
   let fileExtension: '.zip' | '.json' = '.json'
   let outputJsonString = ''
-  const selectedFileType = generateOutputState.selectedFileType
 
   if (selectedFileType === 'json-separate') {
     outputJsonString = JSON.stringify({ testAnswerKey: testAnswerKeyData }, null, 2)
   }
   else {
-    outputJsonString = JSON.stringify(uploadedData.jsonData, null, 2)
+    const jsonData = fileUploaderState.jsonData ?? {}
+    jsonData.testAnswerKey = testAnswerKeyData
 
-    if (selectedFileType === 'zip' && uploadedData.pdfFile) {
+    outputJsonString = JSON.stringify(jsonData, null, 2)
+
+    if (selectedFileType === 'zip' && fileUploaderState.unzippedFiles) {
       fileExtension = '.zip'
     }
   }
@@ -826,17 +811,12 @@ async function downloadOutput() {
     generateOutputState.downloaded = true
   }
   else {
-    const pdfU8Array = uploadedData.pdfFile
-    if (!pdfU8Array) return
+    if (!fileUploaderState.unzippedFiles) return
 
     const jsonU8Array = strToU8(outputJsonString)
+    fileUploaderState.unzippedFiles[DataFileNames.dataJson] = [jsonU8Array, { level: 6 }]
 
-    const zipFiles: AsyncZippable = {}
-
-    zipFiles[DataFileNames.questionsPdf] = pdfU8Array
-    zipFiles[DataFileNames.dataJson] = [jsonU8Array, { level: 6 }]
-
-    zip(zipFiles, { level: 0 }, (err, compressedZip) => {
+    zip(fileUploaderState.unzippedFiles, { level: 0 }, (err, compressedZip) => {
       if (err) {
         console.error('Error creating zip:', err)
         return
@@ -866,7 +846,7 @@ async function loadDataFromDB() {
         if (subjectsData) {
           dbTestOutputDataState.isDataFound = false
           dbTestOutputDataState.testResultOverviews = []
-          loadDataState({}, null)
+          loadDataState()
           dbTestOutputDataState.isDataFromDB = true
           generateOutputState.selectedFileType = 'json-separate'
         }

--- a/pages/cbt/interface.vue
+++ b/pages/cbt/interface.vue
@@ -173,10 +173,16 @@
             v-model:test-state="testState"
             @prepare-test="prepareTest"
           />
-          <LazyCbtInterfacePrepareTest
+          <LazyGenerateTestImages
             v-else-if="testState.currentProcess === 'preparing-imgs'"
-            v-model:test-state="testState"
+            :pdf-uint8-array="testState.pdfFile"
             :question-img-scale="testSettings.questionImgScale"
+            :cropper-sections-data="cropperSectionsData"
+            @current-question-progress="(questionNum) => testState.preparingTestCurrentQuestion = questionNum"
+            @done-generating="() => {
+              testState.currentProcess = 'test-is-ready'
+              testState.pdfFile = null
+            }"
           />
           <CbtInterfaceQuestionPanel
             v-else-if="testState.currentProcess === 'test-is-ready' || testState.currentProcess === 'test-started'"

--- a/pages/cbt/interface.vue
+++ b/pages/cbt/interface.vue
@@ -179,10 +179,7 @@
             :question-img-scale="testSettings.questionImgScale"
             :cropper-sections-data="cropperSectionsData"
             @current-question-progress="(questionNum) => testState.preparingTestCurrentQuestion = questionNum"
-            @done-generating="() => {
-              testState.currentProcess = 'test-is-ready'
-              testState.pdfFile = null
-            }"
+            @image-blobs-generated="loadQuestionsImgUrlsFromBlobs"
           />
           <CbtInterfaceQuestionPanel
             v-else-if="testState.currentProcess === 'test-is-ready' || testState.currentProcess === 'test-started'"
@@ -579,6 +576,7 @@ import type {
   QuestionAnswer,
   TestOutputData,
   TestSummaryDataTableRow,
+  TestImageBlobs,
 } from '~/src/types'
 import { db } from '~/src/db/cbt-db'
 import { CbtUseState } from '~/src/types/enums'
@@ -663,6 +661,7 @@ const testLogger = useCbtLogger(true)
 
 const testState = shallowReactive<TestState>({
   pdfFile: null,
+  testImageBlobs: null,
   pdfFileHash: '',
   testAnswerKey: null,
   isSectionsDataLoaded: false,
@@ -696,7 +695,7 @@ const {
   testQuestionsData,
   testSectionsSummary,
   currentTestState,
-  testSectionsImgUrls,
+  testQuestionsUrls,
 } = useCbtTestData()
 
 useCreateSectionsSummary(testSectionsData, testSectionsSummary)
@@ -1020,7 +1019,19 @@ async function prepareTest() {
     }
   }
 
-  testState.currentProcess = 'preparing-imgs'
+  if (testState.pdfFile) {
+    testState.currentProcess = 'preparing-imgs'
+  }
+  else {
+    loadQuestionsImgUrlsFromBlobs(testState.testImageBlobs!)
+  }
+}
+
+const loadQuestionsImgUrlsFromBlobs = (testImageBlobs: TestImageBlobs) => {
+  testQuestionsUrls.value = utilGetQuestionsUrlsFromTestImageBlobs(testImageBlobs, testQuestionsData.value)
+  testState.testImageBlobs = null
+  testState.pdfFile = null
+  testState.currentProcess = 'test-is-ready'
 }
 
 const pauseTestHandler = () => {
@@ -1190,23 +1201,9 @@ function generateTestOutputData() {
 }
 
 function loadQuestionImgUrlsToResultsUrlsState(testId: number) {
-  const sectionsUrls = testSectionsImgUrls.value
-  const sectionsData = testSectionsData.value
-  const questionsUrls: Record<string | number, string[]> = {}
+  const questionsUrls = testQuestionsUrls.value
 
-  let isAdded = false
-
-  for (const [section, questions] of Object.entries(sectionsUrls)) {
-    for (const [oriQueId, questionUrls] of Object.entries(questions)) {
-      const queId = sectionsData?.[section]?.[oriQueId]?.queId || 0
-      if (queId === 0) return
-
-      questionsUrls[queId] = questionUrls
-      isAdded = true
-    }
-  }
-
-  if (isAdded) {
+  if (Object.keys(questionsUrls).length > 0) {
     const resultsStateUrls = useCbtResultsTestQuestionsImgUrls()
     resultsStateUrls.value[testId] = questionsUrls
   }

--- a/pages/pdf-cropper.vue
+++ b/pages/pdf-cropper.vue
@@ -439,7 +439,6 @@
     </Dialog>
     <LazyGenerateTestImages
       v-if="generateOutputState.generatingImages && (generateOutputState.totalQuestions > 0)"
-      :is-images-for-pdf-cropper="true"
       :pdf-uint8-array="pdfState.fileUint8Array"
       :question-img-scale="generateOutputState.preGenerateImagesScale"
       :cropper-sections-data="cropperSectionsDataForPreGenerateImages"

--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,0 +1,1 @@
+export const IMAGE_FILE_NAME_OF_ZIP_SEPARATOR = '__--__'

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -338,3 +338,9 @@ export type ScoreCardData = Required<Omit<TestResultOverview['overview'], 'accur
   }
   testDuration?: number
 }
+
+export type TestImageBlobs = {
+  [section: TestSectionKey]: {
+    [question: number | string]: Blob[]
+  }
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -76,7 +76,7 @@ export interface CurrentQuestionData {
   incorrectMarks: number
 }
 
-export type TestSectionKey = string | number
+export type TestSectionKey = string
 
 export type CropperPdfCoords = {
   page: number
@@ -105,7 +105,7 @@ export type CropperSectionsData = {
 }
 
 export type CropperOutputData = {
-  [subject: number | string]: CropperSectionsData
+  [subject: string]: CropperSectionsData
 }
 
 export type QuestionAnswer = number | number[] | string | null
@@ -293,8 +293,15 @@ export type TestResultCommonOutput = TestResultsOutputData | TestOutputData
 export type TestResultsOutputData = Omit<TestOutputData, 'testData' | 'testAnswerKey'>
   & Required<Pick<TestOutputData, 'testResultData'>>
 
+export type TestImageBlobs = {
+  [section: TestSectionKey]: {
+    [question: number | string]: Blob[]
+  }
+}
+
 export interface TestState {
-  pdfFile: null | Uint8Array
+  pdfFile: Uint8Array | null
+  testImageBlobs: TestImageBlobs | null
   pdfFileHash: string
   testAnswerKey: null | TestAnswerKeyData
   isSectionsDataLoaded: boolean
@@ -339,8 +346,12 @@ export type ScoreCardData = Required<Omit<TestResultOverview['overview'], 'accur
   testDuration?: number
 }
 
-export type TestImageBlobs = {
-  [section: TestSectionKey]: {
-    [question: number | string]: Blob[]
-  }
+export type UploadedTestData = {
+  pdfBuffer: Uint8Array | null
+  testImageBlobs: TestImageBlobs | null
+  jsonData: Record<string, unknown> | null
+}
+
+export type QuestionsImageUrls = {
+  [queId: number | string]: string[]
 }

--- a/src/worker/mupdf.worker.ts
+++ b/src/worker/mupdf.worker.ts
@@ -2,7 +2,7 @@
 
 import * as Comlink from 'comlink'
 import type { Document, Pixmap } from 'mupdf'
-import type { TestSectionKey } from '~/src/types'
+import type { TestSectionKey, TestImageBlobs } from '~/src/types'
 
 interface PdfData {
   page: number
@@ -20,12 +20,6 @@ type ProcessedCropperData = {
     section: TestSectionKey
     question: number | string
   }[]
-}
-
-type TestQuestionsBlobs = {
-  [section: TestSectionKey]: {
-    [question: number | string]: Blob[]
-  }
 }
 
 export class MuPdfProcessor {
@@ -85,15 +79,16 @@ export class MuPdfProcessor {
   async generateQuestionImages(
     processedCropperData: ProcessedCropperData,
     scale: number,
+    transparent: boolean = false,
   ) {
     if (!this.doc) throw new Error('PDF not loaded')
 
     let progressCount = 0
-    const imageBlobs: TestQuestionsBlobs = {}
+    const imageBlobs: TestImageBlobs = {}
 
     for (const pageKey of Object.keys(processedCropperData)) {
       const pageNum = parseInt(pageKey)
-      const pagePixmap = await this.getPagePixmap(pageNum, scale)
+      const pagePixmap = await this.getPagePixmap(pageNum, scale, transparent)
 
       for (const questionData of processedCropperData[pageKey]) {
         const { pdfData, section, question } = questionData

--- a/utils/utilGetQuestionsUrlsFromTestImageBlobs.ts
+++ b/utils/utilGetQuestionsUrlsFromTestImageBlobs.ts
@@ -1,0 +1,19 @@
+import type { QuestionsImageUrls, TestImageBlobs, TestQuestionData } from '~/src/types'
+
+export default (
+  testImageBlobs: TestImageBlobs,
+  questionsRelationData: Map<number | string, TestQuestionData>
+    | [string | number, { que: number, section: string }][],
+): QuestionsImageUrls => {
+  const questionsImageUrls: QuestionsImageUrls = {}
+
+  for (const [queId, data] of questionsRelationData) {
+    const { que, section } = data
+    questionsImageUrls[queId] = []
+    testImageBlobs[section][que].forEach((blob) => {
+      questionsImageUrls[queId].push(URL.createObjectURL(blob))
+    })
+  }
+
+  return questionsImageUrls
+}

--- a/utils/utilGetQuestionsUrlsFromTestImageBlobs.ts
+++ b/utils/utilGetQuestionsUrlsFromTestImageBlobs.ts
@@ -3,7 +3,7 @@ import type { QuestionsImageUrls, TestImageBlobs, TestQuestionData } from '~/src
 export default (
   testImageBlobs: TestImageBlobs,
   questionsRelationData: Map<number | string, TestQuestionData>
-    | [string | number, { que: number, section: string }][],
+    | [string | number, { que: number | string, section: string }][],
 ): QuestionsImageUrls => {
   const questionsImageUrls: QuestionsImageUrls = {}
 

--- a/utils/utilUnzipTestDataFile.ts
+++ b/utils/utilUnzipTestDataFile.ts
@@ -1,0 +1,108 @@
+import { unzip, strFromU8, type Unzipped } from 'fflate'
+import { IMAGE_FILE_NAME_OF_ZIP_SEPARATOR } from '~/src/shared/constants'
+import type { CropperOutputData, TestImageBlobs, UploadedTestData } from '~/src/types'
+import { DataFileNames } from '~/src/types/enums'
+
+type UnzippedData = UploadedTestData & {
+  unzippedFiles?: Unzipped
+}
+
+export default (
+  zipFile: File | Blob,
+  requiredData: 'json-only' | 'pdf-or-images-only' | 'all',
+  alsoReturnUnzippedFiles: boolean = false,
+) => {
+  return new Promise<UnzippedData>((resolve, reject) => {
+    zipFile.arrayBuffer()
+      .then((zipBuffer) => {
+        unzip(new Uint8Array(zipBuffer), (err, files) => {
+          if (err) {
+            reject(`Error: ${err.message}!`)
+            return
+          }
+
+          const data: UnzippedData = {
+            pdfBuffer: null,
+            testImageBlobs: null,
+            jsonData: null,
+          }
+
+          const jsonFile = files[DataFileNames.dataJson]
+          const jsonData = jsonFile ? JSON.parse(strFromU8(jsonFile)) : null
+          const pdfFile = files[DataFileNames.questionsPdf]
+
+          if (requiredData === 'pdf-or-images-only' || requiredData === 'all') {
+            if (pdfFile) {
+              data.pdfBuffer = pdfFile
+            }
+            else if (jsonData && Object.keys(files).length > 1) {
+              const pdfCropperData = jsonData.pdfCropperData as CropperOutputData
+              if (!pdfCropperData) {
+                reject('Error: PDF Cropper data not found in data.json of Zip file!')
+                return
+              }
+              const imageBlobs: TestImageBlobs = {}
+              try {
+                for (const subjectData of Object.values(pdfCropperData)) {
+                  for (const [section, sectionData] of Object.entries(subjectData)) {
+                    imageBlobs[section] = {}
+                    const sectionNamwWithSeparator = section + IMAGE_FILE_NAME_OF_ZIP_SEPARATOR
+
+                    for (const [question, questionData] of Object.entries(sectionData)) {
+                      const { pdfData } = questionData
+
+                      if (Array.isArray(pdfData) && pdfData.length > 0) {
+                        const qImagesCount = pdfData.length
+                        const questionNameWithSeparator = question + IMAGE_FILE_NAME_OF_ZIP_SEPARATOR
+
+                        imageBlobs[section][question] = []
+                        for (let i = 0; i < qImagesCount; i++) {
+                          const filename = `${sectionNamwWithSeparator}${questionNameWithSeparator}${i + 1}.png`
+                          const imageBuffer = files[filename]
+                          if (imageBuffer) {
+                            const blob = new Blob([imageBuffer], { type: 'image/png' })
+                            imageBlobs[section][question].push(blob)
+                          }
+                          else {
+                            reject(`Error: Image (png) file for Section "${section}", Question "${question}", image "${i + 1}" is not found in Zip file!`)
+                            return
+                          }
+                        }
+                      }
+                      else {
+                        reject('Error: PDF Data not found in data.json of Zip file!')
+                        return
+                      }
+                    }
+                  }
+                }
+                data.testImageBlobs = imageBlobs
+              }
+              catch {
+                reject('Error: Unable to get images from Zip file, pdf cropper data in data.json is probably not in valid format!')
+                return
+              }
+            }
+            else {
+              reject('Error: PDF/Images files and data.json file are not found in Zip file!')
+              return
+            }
+          }
+
+          if (requiredData === 'json-only' || requiredData === 'all') {
+            if (jsonData) {
+              data.jsonData = jsonData
+            }
+            else {
+              reject('Error: data.json file is not found in Zip file!')
+              return
+            }
+          }
+          if (alsoReturnUnzippedFiles) {
+            data.unzippedFiles = files
+          }
+          resolve(data)
+        })
+      })
+  })
+}

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -114,6 +114,9 @@ export const utilGetTestResultOverview = (
 
 export const utilIsPdfFile = (file: File): Promise<0 | 1 | 2> => {
   return new Promise((resolve, reject) => {
+    if (file.size <= 2) {
+      return resolve(0)
+    }
     const reader = new FileReader()
     reader.onload = (e) => {
       const results = e.target?.result
@@ -138,6 +141,9 @@ export const utilIsPdfFile = (file: File): Promise<0 | 1 | 2> => {
 
 export const utilIsZipFile = (file: File | Blob): Promise<0 | 1 | 2> => {
   return new Promise((resolve, reject) => {
+    if (file.size <= 2) {
+      return resolve(0)
+    }
     const reader = new FileReader()
 
     reader.onload = (e) => {


### PR DESCRIPTION
Add option on test interface and result page's question preview to use pre generated images if found in zip file.

If both PDF and Image files are found in zip file (which implies user added it by himself) then prioritize PDF to generate images again instead of using pre generated ones in zip file.