### PR TITLE
fix(pdf-cropper): refactor cropped overlay data structure and fix issues around merged questions

### DIFF
--- a/app/components/PdfCropper/PdfCropperCropOverlay.vue
+++ b/app/components/PdfCropper/PdfCropperCropOverlay.vue
@@ -7,10 +7,10 @@
       'pointer-events-none': currentMode !== 'crop',
     }"
     :style="{
-      '--l': currentOverlayData.pdfData[0]!.l,
-      '--t': currentOverlayData.pdfData[0]!.t,
-      '--r': currentOverlayData.pdfData[0]!.r,
-      '--b': currentOverlayData.pdfData[0]!.b,
+      '--l': currentOverlayData.pdfData.l,
+      '--t': currentOverlayData.pdfData.t,
+      '--r': currentOverlayData.pdfData.r,
+      '--b': currentOverlayData.pdfData.b,
     }"
     @contextmenu.prevent="(e) => {
       if (cropperMode.isBox) {
@@ -92,7 +92,7 @@ const currentOverlayData = defineModel<PdfCroppedOverlayData>('currentOverlayDat
 const blurCroppedRegion = defineModel<boolean>('blurCroppedRegion', { required: true })
 
 const emit = defineEmits<{
-  setPdfData: [data: PdfCroppedOverlayData['pdfData'][number]]
+  setPdfData: [data: PdfCroppedOverlayData['pdfData']]
 }>()
 
 const overlayContainerElem = useTemplateRef('overlayContainerElem')
@@ -124,7 +124,7 @@ const skipNextLine = computed({
 
 const undoLastCoordLine = () => {
   if (props.currentMode !== 'crop' || !props.cropperMode.isLine) return
-  const pdfData = currentOverlayData.value.pdfData[0]!
+  const pdfData = currentOverlayData.value.pdfData
   switch (lineCropperState.currentCoord) {
     case 'b':
       lineCropperState.currentCoord = 't'
@@ -227,8 +227,7 @@ const onBoxPointerDown = (e: PointerEvent) => {
   if (!props.cropperMode.isBox || props.currentMode !== 'crop') return
   if (!overlayContainerElem.value) return
 
-  const pdfData = currentOverlayData.value.pdfData[0]
-  if (!pdfData) return
+  const pdfData = currentOverlayData.value.pdfData
 
   const rect = overlayContainerElem.value.getBoundingClientRect()
   const xRel = e.clientX - rect.left
@@ -259,8 +258,7 @@ const onPointerMove = (e: PointerEvent) => {
   const yRel = e.clientY - rect.top
 
   if (props.cropperMode.isBox && boxCropperState.isDragging) {
-    const pdfData = currentOverlayData.value.pdfData[0]
-    if (!pdfData) return
+    const pdfData = currentOverlayData.value.pdfData
 
     const x = utilClampNumber(xRel, 0, props.pageWidth, props.pageScale)
     const y = utilClampNumber(yRel, 0, props.pageHeight, props.pageScale)
@@ -272,8 +270,7 @@ const onPointerMove = (e: PointerEvent) => {
   }
   else if (props.cropperMode.isLine) {
     const currentCoord = lineCropperState.currentCoord
-    const pdfData = currentOverlayData.value.pdfData[0]
-    if (!pdfData) return
+    const pdfData = currentOverlayData.value.pdfData
 
     switch (currentCoord) {
       case 'l':
@@ -297,11 +294,9 @@ const onBoxPointerUp = (e: PointerEvent) => {
   onPointerMove(e)
   cleanUpEventListeners(null, ['pointerdown'])
   boxCropperState.isDragging = false
-  const pdfData = utilCloneJson(currentOverlayData.value.pdfData[0])
-  if (pdfData) {
-    pdfData.page = props.currentPageNum
-    emit('setPdfData', pdfData)
-  }
+  const pdfData = utilCloneJson(currentOverlayData.value.pdfData)
+  pdfData.page = props.currentPageNum
+  emit('setPdfData', pdfData)
 }
 
 const throttledOnPointerMove = useThrottleFn(onPointerMove, () => props.selectionThrottleInterval, true)
@@ -319,8 +314,8 @@ const setLineCropperCoord = () => {
       lineCropperState.currentCoord = 'b'
       break
     case 'b': {
-      const pdfData = currentOverlayData.value.pdfData[0]
-      if (!pdfData) return
+      const pdfData = currentOverlayData.value.pdfData
+
       const { t, b } = pdfData
       pdfData.t = Math.min(b, t)
       pdfData.b = Math.max(b, t)
@@ -395,8 +390,7 @@ const onKeyDown = (e: KeyboardEvent) => {
 
   e.preventDefault()
 
-  const pdfData = currentOverlayData.value.pdfData[0]
-  if (!pdfData) return
+  const pdfData = currentOverlayData.value.pdfData
 
   if (currentCoord === 'l' || currentCoord === 'r') {
     const { l, r } = pdfData
@@ -468,8 +462,7 @@ watch(() => props.currentPageNum,
       if (lineCropperState.currentCoord === 'b') {
         skipNextLine.value = false
         lineCropperState.currentCoord = 't'
-        const pdfData = currentOverlayData.value.pdfData[0]
-        if (pdfData) pdfData.b = 0
+        currentOverlayData.value.pdfData.b = 0
       }
     }
   },

--- a/app/utils/utilUnzipTestDataFile.ts
+++ b/app/utils/utilUnzipTestDataFile.ts
@@ -1,6 +1,5 @@
 import { unzip, strFromU8, type Unzipped } from 'fflate'
-import { IMAGE_FILE_NAME_OF_ZIP_SEPARATOR } from '#shared/constants'
-import { DataFileNames } from '#shared/enums'
+import { DataFileNames, Constants } from '#shared/enums'
 
 type UnzippedData = UploadedTestData & {
   unzippedFiles?: Unzipped
@@ -50,14 +49,14 @@ export default (
                 for (const subjectData of Object.values(pdfCropperData)) {
                   for (const [section, sectionData] of Object.entries(subjectData)) {
                     imageBlobs[section] = {}
-                    const sectionNamwWithSeparator = section + IMAGE_FILE_NAME_OF_ZIP_SEPARATOR
+                    const sectionNamwWithSeparator = section + Constants.separator
 
                     for (const [question, questionData] of Object.entries(sectionData)) {
                       const { pdfData } = questionData
 
                       if (Array.isArray(pdfData) && pdfData.length > 0) {
                         const qImagesCount = pdfData.length
-                        const questionNameWithSeparator = question + IMAGE_FILE_NAME_OF_ZIP_SEPARATOR
+                        const questionNameWithSeparator = question + Constants.separator
 
                         imageBlobs[section][question] = []
                         for (let i = 0; i < qImagesCount; i++) {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,4 +1,2 @@
-export const IMAGE_FILE_NAME_OF_ZIP_SEPARATOR = '__--__'
-
 export const OVERALL = ' Overall'
 export const TEST_OVERALL = 'Test Overall'

--- a/shared/enums.ts
+++ b/shared/enums.ts
@@ -44,3 +44,7 @@ export enum CBTInterfaceQueryParams {
   allowPause = 'allowpause',
   imageScale = 'imagescale',
 }
+
+export enum Constants {
+  separator = '__--__',
+}

--- a/shared/types/index.d.ts
+++ b/shared/types/index.d.ts
@@ -115,10 +115,15 @@ export type TestQuestionData = Pick<CropperQuestionData, 'que' | 'type'> & {
   totalOptions?: number
 }
 
-export type PdfCroppedOverlayData = Omit<CropperQuestionData, 'marks' | 'pdfData'> & {
+export type PdfCroppedOverlayData = {
   id: string
+  queId: string
+  que: number
   subject: string
   section: string
+  imgNum: number
+  type: QuestionType
+  options?: number
   marks: Required<QuestionMarks>
   pdfData: {
     l: number // left
@@ -126,8 +131,10 @@ export type PdfCroppedOverlayData = Omit<CropperQuestionData, 'marks' | 'pdfData
     t: number // top
     b: number // bottom
     page: number // page number
-  }[]
+  }
 }
+
+export type PdfCropperOverlaysPerQuestion = Map<string, number>
 
 export type ActiveCroppedOverlay = {
   id: string


### PR DESCRIPTION
Simplify data structure by replacing pdfData arrays with single objects.
Add queId and imgNum for unique question identification.
Implement overlaysPerQuestionData map to track image counts.
Change active overlay tracking from {id, imgNum} to single activeId.
Disable Ques Type, Answer Options, Marking Scheme input fields for overlays that belong to a merged question, so that these data can only be changed through 1st overlay of that question.
Add visual difference (text color) to Question Details header in UI for selected overlays in Edit Mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved overlay management in the PDF cropper, allowing multiple cropped regions per question to be handled more intuitively.
  - Enhanced display of question details, including clearer indicators for multi-image questions and input controls.

- **Refactor**
  - Simplified the structure for cropped overlay data, consolidating from arrays to single coordinate objects for greater consistency and easier editing.
  - Streamlined overlay editing controls and event handling for a more user-friendly experience.

- **Style**
  - Updated panel and overlay visuals for better readability and interaction feedback.

- **Chores**
  - Updated internal constants and type definitions to improve maintainability and data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->