### PR TITLE
feat: add ability to load existing data to edit on pdf cropper page, and in generate answer key page load answer key present in the loaded json data

### DIFF
--- a/apps/shared/app/components/Cbt/Results/ChartsPanel.vue
+++ b/apps/shared/app/components/Cbt/Results/ChartsPanel.vue
@@ -343,6 +343,8 @@ const chartOptions = {
           ? null
           : `<p>Subject: ${subject}</p>`
 
+        const stringifyAnswerSeparators = { msm: { rows: '<br>' } }
+
         // user answer won't be shown if it is null
         let yourAnswerContentText = ''
         if (answer !== null) {
@@ -358,7 +360,7 @@ const chartOptions = {
                   color = chartColors.resultStatus.partial
                 }
                 yourAnswerContentText += `
-                    <span style="color: ${color};">${utilStringifyAnswer(ans, type, false, ', ', '<br>')}&nbsp</span>
+                    <span style="color: ${color};">${utilStringifyAnswer(ans, type, false, stringifyAnswerSeparators)}&nbsp</span>
                   `
               })
               yourAnswerContentText += '</p>'
@@ -366,7 +368,7 @@ const chartOptions = {
             else {
               yourAnswerContentText += `
                   <span style="color: ${chartColors.resultStatus[resultStatus]};">
-                    ${utilStringifyAnswer(sortedAnswer, type, false, ', ', '<br>')}
+                    ${utilStringifyAnswer(sortedAnswer, type, false, stringifyAnswerSeparators)}
                   </span></p>
                 `
             }
@@ -374,7 +376,7 @@ const chartOptions = {
           else {
             yourAnswerContentText += `
                 <span style="color: ${chartColors.resultStatus[resultStatus]};">
-                  ${utilStringifyAnswer(answer, type, true, ', ', '<br>')}
+                  ${utilStringifyAnswer(answer, type, true, stringifyAnswerSeparators)}
                 </span></p>
               `
           }
@@ -391,7 +393,7 @@ const chartOptions = {
             ${yourAnswerContentText || ''}
             <p>Correct Answer:
               <span style="color: ${chartColors.resultStatus.correct};">
-                ${utilStringifyAnswer(correctAnswer, type, true, ', ', '<br>')}
+                ${utilStringifyAnswer(correctAnswer, type, true, stringifyAnswerSeparators)}
               </span>
             </p>
             <p>Result:

--- a/apps/shared/app/components/PdfCropper/EditExistingFilesDialog.vue
+++ b/apps/shared/app/components/PdfCropper/EditExistingFilesDialog.vue
@@ -1,0 +1,125 @@
+<template>
+  <UiDialog
+    v-model:open="showDialog"
+  >
+    <UiDialogContent>
+      <UiDialogHeader>
+        <UiDialogTitle class="mx-auto">
+          Upload Existing File(s) To Edit
+        </UiDialogTitle>
+      </UiDialogHeader>
+      <UiDialogDescription>
+        Upload PDF and ZIP/JSON files downloaded from PDF Cropper OR Answer Key Page.<br>
+        If ZIP file contains PDF file (when images not pre-generated) then no need to upload PDF file.
+      </UiDialogDescription>
+      <div class="flex flex-col sm:flex-row items-center justify-center gap-5 my-3">
+        <BaseSimpleFileUpload
+          accept="application/zip,application/json,.zip,.json"
+          :label="uploadedFiles.zipOrJsonFile ? 'Change JSON/ZIP file' : 'Select ZIP/JSON file'"
+          :variant="uploadedFiles.zipOrJsonFile ? 'success' : 'help'"
+          invalid-file-type-message="Please select a valid PDF file."
+          @upload="(file) => uploadedFiles.zipOrJsonFile = file"
+        />
+        <BaseSimpleFileUpload
+          accept="application/pdf,.pdf"
+          :label="uploadedFiles.pdfFile ? 'Change PDF file' : 'Select PDF file'"
+          :variant="uploadedFiles.pdfFile ? 'success' : 'help'"
+          invalid-file-type-message="Please select a valid PDF file."
+          @upload="(file) => uploadedFiles.pdfFile = file"
+        />
+      </div>
+      <UiDialogFooter>
+        <BaseButton
+          label="Load Files"
+          :disabled="!uploadedFiles.zipOrJsonFile"
+          variant="warn"
+          @click="loadFiles"
+        />
+      </UiDialogFooter>
+    </UiDialogContent>
+  </UiDialog>
+</template>
+
+<script lang="ts" setup>
+type EmitedData = {
+  pdfBuffer: Uint8Array
+  jsonData: PdfCropperJsonOutput | AnswerKeyJsonOutputBasedOnPdfCropper
+}
+const showDialog = defineModel<boolean>({ required: true })
+
+const uploadedFiles = shallowReactive({
+  pdfFile: null as File | null,
+  zipOrJsonFile: null as File | null,
+})
+
+const emit = defineEmits<{
+  uploadedData: [data: EmitedData]
+}>()
+
+const migrateJsonData = useMigrateJsonData()
+
+async function loadFiles() {
+  const { pdfFile, zipOrJsonFile } = uploadedFiles
+  if (!zipOrJsonFile) return
+
+  let pdfBuffer: Uint8Array | null = null
+  let jsonData: PdfCropperJsonOutput | AnswerKeyJsonOutputBasedOnPdfCropper | null = null
+  try {
+    if (pdfFile) {
+      const pdfFileCheck = await utilIsPdfFile(pdfFile)
+      if (pdfFileCheck > 0)
+        pdfBuffer = new Uint8Array(await pdfFile.arrayBuffer())
+    }
+
+    const zipCheckStatus = await utilIsZipFile(zipOrJsonFile)
+    if (zipCheckStatus > 0) {
+      const unzipped = await utilUnzipTestDataFile(zipOrJsonFile, 'json-and-maybe-pdf')
+      jsonData = unzipped.jsonData
+      pdfBuffer = unzipped.pdfBuffer
+    }
+    else {
+      jsonData = await utilParseJsonFile(zipOrJsonFile)
+    }
+
+    if (!pdfBuffer) {
+      if (pdfFile) {
+        const pdfFileCheck = await utilIsPdfFile(pdfFile)
+        if (pdfFileCheck > 0) {
+          pdfBuffer = new Uint8Array(await pdfFile.arrayBuffer())
+        }
+        else {
+          throw new Error(`${pdfFile.name} is not a valid PDF file`)
+        }
+      }
+      else {
+        const msg = zipCheckStatus > 0
+          ? `PDF is not present in the ZIP file, you need to upload the PDF file separately.`
+          : 'Please also upload the PDF file.'
+        throw new Error(msg)
+      }
+    }
+
+    if (!jsonData) {
+      throw new Error('JSON Data is not found or is invalid.')
+    }
+
+    if (!jsonData.pdfCropperData) {
+      throw new Error(
+        'PDf Cropper Data is not found in JSON data. '
+        + 'Make sure you are uploading file downloaded from PDF Cropper Page or Generate Answer Key Page.',
+      )
+    }
+    jsonData = 'testAnswerKey' in jsonData
+      ? migrateJsonData.answerKeyData(jsonData) as AnswerKeyJsonOutputBasedOnPdfCropper
+      : migrateJsonData.pdfCropperData(jsonData)
+
+    if (Object.keys(jsonData.pdfCropperData).length > 0) {
+      emit('uploadedData', { pdfBuffer, jsonData })
+      showDialog.value = false
+    }
+  }
+  catch (err) {
+    useErrorToast('Error loading files', err, undefined, false)
+  }
+}
+</script>

--- a/apps/shared/app/composables/useErrorToast.ts
+++ b/apps/shared/app/composables/useErrorToast.ts
@@ -7,8 +7,10 @@ export default (
   title: string,
   err: any = '', // eslint-disable-line @typescript-eslint/no-explicit-any
   data: Parameters<typeof toastType['error']>[1] | null = undefined,
+  printToConsole: boolean = true,
 ) => {
-  console.error(title, err)
+  if (printToConsole)
+    console.error(title, err)
 
   toast ??= useNuxtApp().$toast
 

--- a/apps/shared/app/src/scripts/migrate-json-data.ts
+++ b/apps/shared/app/src/scripts/migrate-json-data.ts
@@ -53,7 +53,7 @@ export class MigrateJsonData {
     }
   }
 
-  private removeEmptyKeysFromTestConfig<
+  removeEmptyKeysFromTestConfig<
     T extends (TestInterfaceAndResultCommonJsonOutputData['testConfig'] | PdfCropperJsonOutput['testConfig']),
   >(testConfig: T) {
     for (const key of Object.keys(testConfig) as (keyof T)[])
@@ -67,8 +67,8 @@ export class MigrateJsonData {
       }
   }
 
-  pdfCropperData(data: any): PdfCropperJsonOutput {
-    const output: PdfCropperJsonOutput = {
+  getPdfCropperJsonOutputTemplate(): PdfCropperJsonOutput {
+    return {
       testConfig: {
         zipConvertedUrl: '',
         zipOriginalUrl: '',
@@ -80,7 +80,12 @@ export class MigrateJsonData {
       appVersion: this.currentAppVersion,
       generatedBy: 'pdfCropperPage',
     }
+  }
 
+  pdfCropperData(
+    data: any,
+    output = this.getPdfCropperJsonOutputTemplate(),
+  ): PdfCropperJsonOutput {
     if (!('appVersion' in data)) {
       if ('pdfFileHash' in data) {
         output.testConfig.pdfFileHash = data.pdfFileHash

--- a/apps/shared/app/utils/utilSelectiveMergeObj.ts
+++ b/apps/shared/app/utils/utilSelectiveMergeObj.ts
@@ -3,7 +3,7 @@
   given that property name and type of value are same, else ignored
   This function is specificially for settings objects
 */
-const utilSelectiveMergeObj = <T extends Record<string, unknown>>(
+const utilSelectiveMergeObj = <T extends object>(
   target: T,
   data: Partial<T>,
 ): T => {
@@ -29,8 +29,8 @@ const utilSelectiveMergeObj = <T extends Record<string, unknown>>(
       && typeof dataValue === 'object' && dataValue !== null
     ) {
       target[key] = utilSelectiveMergeObj(
-        targetValue as Record<string, unknown>,
-        dataValue as Record<string, unknown>,
+        targetValue,
+        dataValue,
       ) as T[keyof T]
     }
     else if (typeof dataValue === typeof targetValue && targetValue !== dataValue) {

--- a/apps/shared/app/utils/utilUnzipTestDataFile.ts
+++ b/apps/shared/app/utils/utilUnzipTestDataFile.ts
@@ -9,7 +9,7 @@ type UnzippedData = UploadedTestData & {
 
 export default (
   zipFile: File | Blob,
-  requiredData: 'json-only' | 'pdf-or-images-only' | 'pdf-and-json' | 'all',
+  requiredData: 'json-only' | 'pdf-or-images-only' | 'pdf-and-json' | 'json-and-maybe-pdf' | 'all',
   alsoReturnUnzippedFiles: boolean = false,
 ) => {
   return new Promise<UnzippedData>((resolve, reject) => {
@@ -108,6 +108,7 @@ export default (
           if (
             requiredData === 'json-only'
             || requiredData === 'pdf-and-json'
+            || requiredData === 'json-and-maybe-pdf'
             || requiredData === 'all'
           ) {
             if (jsonData) {
@@ -118,6 +119,11 @@ export default (
               return
             }
           }
+
+          if (requiredData === 'json-and-maybe-pdf' && pdfFile) {
+            data.pdfBuffer = pdfFile
+          }
+
           if (alsoReturnUnzippedFiles) {
             data.unzippedFiles = files
           }

--- a/apps/shared/shared/types/pdf-cropper.d.ts
+++ b/apps/shared/shared/types/pdf-cropper.d.ts
@@ -72,3 +72,12 @@ export type ActiveCroppedOverlay = {
   id: string
   imgNum: number
 }
+
+export type PageImgData = {
+  [pageNum: number]: {
+    width: number
+    height: number
+    url: string
+    pageScale: number
+  }
+}


### PR DESCRIPTION
closes #48 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dialog to upload and load existing PDF and answer key data in the PDF Cropper tool.
  * Enhanced PDF Cropper to support importing data from existing files and improved overlay synchronization.
  * Introduced new page metadata display and improved page dimension handling.

* **Bug Fixes**
  * Improved error handling and messaging during file uploads and data loading.

* **Refactor**
  * Simplified file upload logic and dialog state management in PDF Cropper.
  * Streamlined answer string formatting and separator customization across components.
  * Broadened utility function compatibility with more flexible type support.

* **Documentation**
  * Added new type definitions for page image metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->