### PR TITLE
Add scrolling disable feature and question paper preview dialog

### DIFF
--- a/apps/shared/app/components/Cbt/Interface/QuestionPaperDialog.vue
+++ b/apps/shared/app/components/Cbt/Interface/QuestionPaperDialog.vue
@@ -1,0 +1,133 @@
+<script lang="ts" setup>
+import { ref } from 'vue'
+import BaseButton from '@/components/Base/Button.vue'
+
+interface QuestionData {
+  questionID: number
+  questionNo: number
+  questionImgBlobUrl: string
+  section: string
+  sectionQueId: number
+}
+
+function getQuestionsImageData(): QuestionData[] {
+  const result: QuestionData[] = []
+  const { testQuestionsData, testQuestionsUrls } = useCbtTestData()
+
+  testQuestionsData.value.forEach((questionData) => {
+    const { queId, que, secQueId, section } = questionData
+    const questionImgUrls = testQuestionsUrls.value
+    result.push({
+      questionID: queId,
+      questionNo: que,
+      questionImgBlobUrl: questionImgUrls[queId]?.values().next().value ?? '',
+      section: section,
+      sectionQueId: secQueId
+    })
+  })
+
+  return result
+}
+
+const emit = defineEmits(['close'])
+const questionsData = ref<QuestionData[]>(getQuestionsImageData())
+
+function close() {
+  emit('close')
+}
+</script>
+
+<template>
+  <div class="modal-overlay" @click.self="close">
+    <div class="modal">
+      <!-- Header -->
+      <div class="modal-header">
+        <h2 class="title">Question Paper</h2>
+        <BaseButton
+          label="Close"
+          variant="destructive"
+          icon-name="prime:times-circle"
+          size="sm"
+          @click="close"
+        />
+      </div>
+
+      <!-- Content -->
+      <div class="modal-body">
+        <h2 class="text-red-500 mb-4">
+          Note that the timer is ticking while you read the Question Paper. Close
+          this page to return to answering the questions.
+        </h2>
+
+        <div
+          v-for="questionData in questionsData"
+          :key="questionData.questionID"
+          class="mb-4"
+        >
+          <div v-if="questionData.sectionQueId === 1" class="font-semibold text-blue-600">
+            {{ questionData.section }}
+          </div>
+          <div class="mb-1">Question No. {{ questionData.questionNo }}</div>
+          <img
+            :src="questionData.questionImgBlobUrl"
+            alt="Question Image"
+            class="w-full max-w-full rounded border"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  z-index: 1000;
+}
+
+.modal {
+  background: white;
+  border-radius: 10px;
+  min-width: 300px;
+  max-width: 90vw;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  position: sticky;
+  top: 0;
+  z-index: 10;
+
+  background: white;
+  padding: 0.5rem 1.25rem;
+  border-bottom: 1px solid #ddd;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.modal-body {
+  overflow-y: auto;
+  padding: 1.25rem;
+  flex-grow: 1;
+}
+</style>

--- a/apps/shared/app/components/Cbt/Interface/SettingsPanel.vue
+++ b/apps/shared/app/components/Cbt/Interface/SettingsPanel.vue
@@ -198,6 +198,25 @@
                     <div class="grid grid-cols-1 w-full ml-0.5 mt-2">
                       <div class="flex gap-2 w-full justify-center mb-0.5">
                         <UiLabel
+                          for="show_question_paper_dropdown"
+                        >
+                          Show Question Paper
+                        </UiLabel>
+                        <IconWithTooltip
+                          :content="tooltipContent.showQuestionPaper"
+                        />
+                      </div>
+                      <BaseSelect
+                        id="show_question_paper_dropdown"
+                        v-model="testSettings.showQuestionPaper"
+                        size="sm"
+                        :options="selectOptions.showQuestionPaper"
+                        class="col-span-6"
+                      />
+                    </div>
+                    <div class="grid grid-cols-1 w-full ml-0.5 mt-2">
+                      <div class="flex gap-2 w-full justify-center mb-0.5">
+                        <UiLabel
                           for="disable_scrolling_dropdown"
                         >
                           Disable Scrolling
@@ -1273,6 +1292,26 @@ const tooltipContent = {
       ]),
       h('strong', 'You can access hidden settings any time, be it before or during the test.'),
     ]),
+    
+    showQuestionPaper: () =>
+      h('div', { class: 'space-y-2' }, [
+        h('p', 'Previewing the Question Paper'),
+        h('ul', { class: 'list-disc space-y-1 ml-6 [&>li]:mb-1' }, [
+          h('li', [
+            h('strong', 'Timer Active'),
+            ': The test timer will continue running while you are viewing the question paper.',
+          ]),
+          h('li', [
+            h('strong', 'Read Only'),
+            ': This view is for reading only — you cannot answer questions here.',
+          ]),
+          h('li', [
+            h('strong', 'Close to Resume'),
+            ': Close the question paper popup to return to answering the test.',
+          ]),
+        ]),
+        h('strong', 'You can open the question paper again anytime using the Question Paper button.'),
+      ]),
 
   disableScrolling: () =>
     h('div', { class: 'space-y-2' }, [
@@ -1290,7 +1329,6 @@ const tooltipContent = {
       ]),
       h('strong', 'You can change this setting any time in the hidden settings (long-press the profile icon in the top-right corner).'),
     ]),
-
 
   questionImgScale: () =>
     h('div', { class: 'space-y-2' }, [
@@ -1339,6 +1377,11 @@ const selectOptions = {
   ],
 
   showPauseBtn: [
+    { name: 'Yes', value: true },
+    { name: 'No', value: false },
+  ],
+
+  showQuestionPaper: [
     { name: 'Yes', value: true },
     { name: 'No', value: false },
   ],
@@ -1931,6 +1974,7 @@ onMounted(() => {
       const zipurlValue = getFirstQuery(route.query[CBTInterfaceQueryParams.ZipUrl])
       const submitmodeValue = getFirstQuery(route.query[CBTInterfaceQueryParams.SubmitMode])
       const allowpauseValue = getFirstQuery(route.query[CBTInterfaceQueryParams.AllowPause])
+      const showQuestionPaper = getFirstQuery(route.query[CBTInterfaceQueryParams.ShowQuestionPaper])
       const disableScrollingValue = getFirstQuery(route.query[CBTInterfaceQueryParams.DisableScrolling])
       const imgScaleValue = getFirstQuery(route.query[CBTInterfaceQueryParams.ImageScale])
 
@@ -1973,6 +2017,9 @@ onMounted(() => {
       }
       if (allowpauseValue && ['yes', 'no'].includes(allowpauseValue)) {
         testSettings.value.showPauseBtn = allowpauseValue === 'yes'
+      }
+      if (showQuestionPaper && ['yes', 'no'].includes(showQuestionPaper)) {
+        testSettings.value.showQuestionPaper = showQuestionPaper === 'yes'
       }
       if (disableScrollingValue && ['yes', 'no'].includes(disableScrollingValue)) {
         testSettings.value.disableScrolling = disableScrollingValue === 'yes'

--- a/apps/shared/app/components/Cbt/Interface/SettingsPanel.vue
+++ b/apps/shared/app/components/Cbt/Interface/SettingsPanel.vue
@@ -195,6 +195,25 @@
                         class="col-span-6"
                       />
                     </div>
+                    <div class="grid grid-cols-1 w-full ml-0.5 mt-2">
+                      <div class="flex gap-2 w-full justify-center mb-0.5">
+                        <UiLabel
+                          for="disable_scrolling_dropdown"
+                        >
+                          Disable Scrolling
+                        </UiLabel>
+                        <IconWithTooltip
+                          :content="tooltipContent.disableScrolling"
+                        />
+                      </div>
+                      <BaseSelect
+                        id="disable_scrolling_dropdown"
+                        v-model="testSettings.disableScrolling"
+                        size="sm"
+                        :options="selectOptions.disableScrolling"
+                        class="col-span-6"
+                      />
+                    </div>
                     <template v-if="!testState.testImageBlobs">
                       <div class="flex justify-center gap-3 mt-3 w-full">
                         <UiLabel
@@ -1255,6 +1274,24 @@ const tooltipContent = {
       h('strong', 'You can access hidden settings any time, be it before or during the test.'),
     ]),
 
+  disableScrolling: () =>
+    h('div', { class: 'space-y-2' }, [
+      h('p', 'Allow scrolling in the test?'),
+      h('ul', { class: 'list-disc space-y-1 ml-6 [&>li]:mb-1' }, [
+        h('li', [
+          h('strong', 'Yes'),
+          ': Mouse wheel / touchpad scrolling will be disabled inside the test. ',
+          'You will need to use the navigation panel or buttons to move between questions.',
+        ]),
+        h('li', [
+          h('strong', 'No'),
+          ': Scrolling will work normally, and you can freely scroll through questions with your mouse or touchpad.',
+        ]),
+      ]),
+      h('strong', 'You can change this setting any time in the hidden settings (long-press the profile icon in the top-right corner).'),
+    ]),
+
+
   questionImgScale: () =>
     h('div', { class: 'space-y-2' }, [
       h('p', '(This is ignored for ZIP files with pre-generated images)'),
@@ -1306,6 +1343,11 @@ const selectOptions = {
     { name: 'No', value: false },
   ],
 
+  disableScrolling: [
+    { name: 'Yes', value: true },
+    { name: 'No', value: false },
+  ],
+  
   answerOptionsFormat: ANSWER_OPTIONS_COUNTER_TYPES,
 
   showHide: [
@@ -1889,6 +1931,7 @@ onMounted(() => {
       const zipurlValue = getFirstQuery(route.query[CBTInterfaceQueryParams.ZipUrl])
       const submitmodeValue = getFirstQuery(route.query[CBTInterfaceQueryParams.SubmitMode])
       const allowpauseValue = getFirstQuery(route.query[CBTInterfaceQueryParams.AllowPause])
+      const disableScrollingValue = getFirstQuery(route.query[CBTInterfaceQueryParams.DisableScrolling])
       const imgScaleValue = getFirstQuery(route.query[CBTInterfaceQueryParams.ImageScale])
 
       if (nameValue && typeof nameValue === 'string') {
@@ -1930,6 +1973,9 @@ onMounted(() => {
       }
       if (allowpauseValue && ['yes', 'no'].includes(allowpauseValue)) {
         testSettings.value.showPauseBtn = allowpauseValue === 'yes'
+      }
+      if (disableScrollingValue && ['yes', 'no'].includes(disableScrollingValue)) {
+        testSettings.value.disableScrolling = disableScrollingValue === 'yes'
       }
       if (imgScaleValue && !isNaN(Number(imgScaleValue))) {
         testSettings.value.questionImgScale = Number(imgScaleValue)

--- a/apps/shared/app/composables/useCbtSettings.ts
+++ b/apps/shared/app/composables/useCbtSettings.ts
@@ -124,6 +124,7 @@ const defaultTestSettings: CbtTestSettings = {
   timeFormat: 'mmm:ss',
   submitBtn: 'enabled',
   showPauseBtn: false,
+  showQuestionPaper: true,
   disableScrolling: false,
   durationInSeconds: 3 * 60 * 60,
   questionImgScale: 2,

--- a/apps/shared/app/composables/useCbtSettings.ts
+++ b/apps/shared/app/composables/useCbtSettings.ts
@@ -124,6 +124,7 @@ const defaultTestSettings: CbtTestSettings = {
   timeFormat: 'mmm:ss',
   submitBtn: 'enabled',
   showPauseBtn: false,
+  disableScrolling: false,
   durationInSeconds: 3 * 60 * 60,
   questionImgScale: 2,
   saveTestData: true,

--- a/apps/shared/app/pages/cbt/interface.vue
+++ b/apps/shared/app/pages/cbt/interface.vue
@@ -42,10 +42,26 @@
                 icon-class="cursor-pointer text-xl!"
               />
             </div>
+            <div
+              class="flex gap-2 items-center ml-auto"
+              data-id="test_total_summary"
+            >
+            <BaseButton
+                label="Question Paper"
+                variant="info"
+                size="sm"
+                class="mr-1"
+                icon-name="prime:file"
+                v-if="testSettings.showQuestionPaper"
+                :disabled="isTestPaused || testState.currentProcess !== 'test-started'"
+                @click="() => { showQuestionPaper = true }"
+              />
+          </div> 
           </div>
           <div class="flex justify-between px-3 py-0.5 shrink-0">
             <span class="flex ml-auto items-center">Time Left:&nbsp;&nbsp;{{ testTimeLeftString }}</span>
           </div>
+          <QuestionPaperDialog v-if="showQuestionPaper" @close="showQuestionPaper = false" />
           <UiScrollArea
             class="w-full border-slate-400"
             viewport-class="[&>div]:mb-3"
@@ -565,6 +581,7 @@ import markedIcon from '#layers/shared/app/assets/icons/ques-marked.svg?no-inlin
 import markedAnsweredIcon from '#layers/shared/app/assets/icons/ques-markedAnswered.svg?no-inline'
 import profileIcon from '#layers/shared/app/assets/icons/profile.svg?no-inline'
 import { CbtUseState } from '#layers/shared/shared/enums'
+import QuestionPaperDialog from '~/components/Cbt/Interface/QuestionPaperDialog.vue'
 
 definePageMeta({
   layout: false,
@@ -590,6 +607,8 @@ const questionStatusList: {
   { key: 'marked', label: 'Marked for Review' },
   { key: 'markedAnswered', label: 'Answered & Marked for Review', colSpan2: true },
 ]
+
+const showQuestionPaper = ref(false)
 
 const db = useDB()
 

--- a/apps/shared/app/pages/cbt/interface.vue
+++ b/apps/shared/app/pages/cbt/interface.vue
@@ -1112,6 +1112,9 @@ async function submitTest(isAuto: boolean) {
     console.error('Error while saving currentTestState when testFinished', err)
   }
 
+  window.removeEventListener('wheel', preventScroll)
+  window.removeEventListener('touchmove', preventScroll)
+
   generateTestOutputData()
   try {
     const id = await db.addTestOutputData(utilCloneJson(testOutputData!))
@@ -1246,6 +1249,21 @@ const downloadTestData = () => {
   const blob = new Blob([JSON.stringify(testOutputData, null, 2)], { type: 'application/json' })
   utilSaveFile('pdf2cbt_test_data.json', blob)
 }
+
+watch(() => testSettings.value.disableScrolling, (newVal) => {
+  if (newVal) {
+    window.addEventListener('wheel', preventScroll, { passive: false })
+    window.addEventListener('touchmove', preventScroll, { passive: false })
+  } else {
+    window.removeEventListener('wheel', preventScroll)
+    window.removeEventListener('touchmove', preventScroll)
+  }
+})
+
+function preventScroll(e: Event) {
+  e.preventDefault()
+}
+
 
 onBeforeUnmount(pageCleanUpCallback)
 

--- a/apps/shared/shared/enums.ts
+++ b/apps/shared/shared/enums.ts
@@ -50,6 +50,7 @@ export enum CBTInterfaceQueryParams {
   TimeFormat = 'timeformat',
   ZipUrl = 'zipurl',
   AllowPause = 'allowpause',
+  ShowQuestionPaper = 'showQuestionPaper',
   DisableScrolling = 'disableScrolling',
   ImageScale = 'imagescale',
 }

--- a/apps/shared/shared/enums.ts
+++ b/apps/shared/shared/enums.ts
@@ -50,5 +50,6 @@ export enum CBTInterfaceQueryParams {
   TimeFormat = 'timeformat',
   ZipUrl = 'zipurl',
   AllowPause = 'allowpause',
+  DisableScrolling = 'disableScrolling',
   ImageScale = 'imagescale',
 }

--- a/apps/shared/shared/types/cbt-interface.d.ts
+++ b/apps/shared/shared/types/cbt-interface.d.ts
@@ -207,6 +207,7 @@ export interface CbtTestSettings {
   durationInSeconds: number
   submitBtn: 'enabled' | 'disabled' | 'hidden'
   showPauseBtn: boolean
+  disableScrolling: boolean
   questionImgScale: number
   saveTestData: boolean
 }

--- a/apps/shared/shared/types/cbt-interface.d.ts
+++ b/apps/shared/shared/types/cbt-interface.d.ts
@@ -207,6 +207,7 @@ export interface CbtTestSettings {
   durationInSeconds: number
   submitBtn: 'enabled' | 'disabled' | 'hidden'
   showPauseBtn: boolean
+  showQuestionPaper: boolean
   disableScrolling: boolean
   questionImgScale: number
   saveTestData: boolean


### PR DESCRIPTION
This PR introduces two new features:

- Disables mouse wheel and touchpad scrolling during the test to prevent free scrolling and simulate real CBT experience.
- Adds a question paper preview dialog allowing users to view the entire question paper.

These enhancements improve test integrity and user experience.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Question Paper modal with section headers and question images.
  - New header button to open the Question Paper during an active test (hidden/disabled based on state).
  - Settings panel now includes “Show Question Paper” and “Disable Scrolling” toggles.
  - Support for URL parameters to preset these settings (showQuestionPaper, disableScrolling).
- UX
  - Optional global scroll lock during the test when “Disable Scrolling” is enabled.
  - Clear close actions for the modal (overlay click or Close button).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->