### PR TITLE
fix(ui): center QuestionPaperDialog header using grid layout instead of flex

### DIFF
--- a/apps/shared/app/components/Cbt/Interface/QuestionPaperDialog.vue
+++ b/apps/shared/app/components/Cbt/Interface/QuestionPaperDialog.vue
@@ -70,36 +70,38 @@ function resizeImage(type: 'increase' | 'decrease') {
   >
     <div class="flex flex-col bg-white rounded-xl w-[90dvw] h-[90dvh]">
       <!-- Header -->
-      <div class="sticky top-0 z-10 py-2 px-6 flex items-center justify-center gap-4 border-b border-gray-400">
-        <h2 class="text-2xl font-bold ml-auto">
+      <div class="sticky top-0 z-10 py-2 px-6 grid grid-cols-[1fr_auto_1fr] items-center gap-4 border-b border-gray-400">
+        <div></div> <!-- Empty placeholder for left spacing -->
+        <h2 class="text-2xl font-bold text-center">
           Question Paper
         </h2>
-        <BaseButton
-          variant="help"
-          class="ml-auto"
-          size="iconMd"
-          title="Increase Image Size"
-          icon-name="mdi:file-image-plus"
-          icon-class="text-black"
-          :disabled="imgWidthSize >= 100"
-          @click="resizeImage('increase')"
-        />
-        <BaseButton
-          variant="help"
-          size="iconMd"
-          title="Decrease Image Size"
-          icon-name="mdi:file-image-minus"
-          icon-class="text-black"
-          :disabled="imgWidthSize <= 20"
-          @click="resizeImage('decrease')"
-        />
-        <BaseButton
-          variant="destructive"
-          title="Close"
-          icon-name="prime:times-circle"
-          size="iconMd"
-          @click="showDialog = false"
-        />
+        <div class="flex justify-end gap-2">
+          <BaseButton
+            variant="help"
+            size="iconMd"
+            title="Increase Image Size"
+            icon-name="mdi:file-image-plus"
+            icon-class="text-black"
+            :disabled="imgWidthSize >= 100"
+            @click="resizeImage('increase')"
+          />
+          <BaseButton
+            variant="help"
+            size="iconMd"
+            title="Decrease Image Size"
+            icon-name="mdi:file-image-minus"
+            icon-class="text-black"
+            :disabled="imgWidthSize <= 20"
+            @click="resizeImage('decrease')"
+          />
+          <BaseButton
+            variant="destructive"
+            size="iconMd"
+            title="Close"
+            icon-name="prime:times-circle"
+            @click="showDialog = false"
+          />
+        </div>
       </div>
 
       <!-- Content -->


### PR DESCRIPTION
### Summary

This PR fixes the alignment issue with the **QuestionPaperDialog** header by switching from a flex layout to a grid. This centers the heading perfectly while keeping the buttons right-aligned.

---

### Before

<img width="1228" height="108" alt="before" src="https://github.com/user-attachments/assets/9ae184c9-051c-49fd-8447-5dfea6812196" />


* Header used flexbox with `ml-auto` causing the heading to shift off-center.
* Buttons and heading were misaligned.

---

### After

<img width="1228" height="108" alt="after" src="https://github.com/user-attachments/assets/630324ce-1cca-4d5d-8d4b-bcf9b6ee89b5" />


* Header now uses CSS grid with three columns: left spacer, centered heading, and right-aligned buttons.
* Heading is perfectly centered.
* Buttons aligned neatly on the right with consistent spacing.

---

### Notes

* Minimal changes to existing code to preserve button markup and functionality.
* Layout improvements improve user experience and visual balance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Style
  - Refined the Question Paper dialog header for a cleaner, more balanced layout.
  - Title is now consistently centered across screen sizes, improving readability.
  - Action buttons (zoom in/out, close) are grouped on the right with clearer spacing for easier access.
  - Improved visual consistency and responsiveness; the title no longer shifts when controls change.
  - No behavioral changes to resizing, closing, or keyboard shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->