### PR TITLE
feat(cbt-interface): add scroll to top and scroll to bottom icon buttons to question panel

### DIFF
--- a/apps/shared/app/components/Cbt/Interface/SettingsPanel.vue
+++ b/apps/shared/app/components/Cbt/Interface/SettingsPanel.vue
@@ -1327,6 +1327,7 @@ const htmlContent = {
         options: selectOptions.yesNo,
         tooltip: tooltipContent.disableMouseWheel,
       },
+      { type: 'select', key: 'showScrollToTopAndBottomBtns', label: 'Scroll To Top/Bottom Btns' },
     ]),
     questionPanel: {
       answerOptionsFormat: {

--- a/apps/shared/app/components/ui/scroll-area/ScrollArea.vue
+++ b/apps/shared/app/components/ui/scroll-area/ScrollArea.vue
@@ -18,10 +18,12 @@ const props = defineProps<ScrollAreaRootProps & {
 
 const delegatedProps = reactiveOmit(props, 'class', 'viewportClass', 'scrollBarClass')
 
-const scrollAreaRootRef = useTemplateRef<InstanceType<typeof ScrollAreaRoot>>('scrollArea')
+const scrollAreaRootRef = useTemplateRef('scrollArea')
 
+const viewport = computed(() => scrollAreaRootRef.value?.viewport)
 // Expose ScrollAreaRoot's methods to parent
 defineExpose({
+  viewport,
   scrollTopLeft: () => { scrollAreaRootRef.value?.scrollTopLeft() },
   scrollTop: () => { scrollAreaRootRef.value?.scrollTop() },
 })

--- a/apps/shared/app/components/ui/scroll-area/ScrollBar.vue
+++ b/apps/shared/app/components/ui/scroll-area/ScrollBar.vue
@@ -32,7 +32,7 @@ const delegatedProps = reactiveOmit(props, 'class', 'thumbAreaClass')
     data-slot="scroll-area-scrollbar"
     v-bind="delegatedProps"
     :class="
-      cn('flex touch-none bg-gray-500 dark:bg-foreground/20 p-px transition-colors select-none',
+      cn('flex touch-none bg-gray-300 dark:bg-foreground/20 p-px transition-colors select-none',
          orientation === 'vertical'
            && 'h-full w-2.5 border-l border-l-transparent',
          orientation === 'horizontal'
@@ -43,7 +43,7 @@ const delegatedProps = reactiveOmit(props, 'class', 'thumbAreaClass')
     <ScrollAreaThumb
       data-slot="scroll-area-thumb"
       :class="cn(
-        'bg-gray-900 dark:bg-foreground/70 relative flex-1 rounded-full',
+        'bg-gray-600 dark:bg-foreground/70 relative flex-1 rounded-full',
         props.thumbAreaClass,
       )"
     />

--- a/apps/shared/app/composables/useCbtSettings.ts
+++ b/apps/shared/app/composables/useCbtSettings.ts
@@ -14,6 +14,7 @@ const defaultUiSettings: CbtUiSettings = {
     showMarkingScheme: true,
     showQuestionTimeSpent: false,
     showQuestionPaperBtn: true,
+    showScrollToTopAndBottomBtns: true,
     disableMouseWheel: false,
   },
 

--- a/apps/shared/shared/types/cbt-interface.d.ts
+++ b/apps/shared/shared/types/cbt-interface.d.ts
@@ -22,9 +22,10 @@ export type CbtUiSettings = {
     showMarkingScheme: boolean
     showQuestionPaperBtn: boolean
     disableMouseWheel: boolean
+    showQuestionTimeSpent: boolean
+    showScrollToTopAndBottomBtns: boolean
     questionTypeFontSize: number
     markingSchemeFontSize: number
-    showQuestionTimeSpent: boolean
     questionTimeSpentFontSize: number
     questionNumFontSize: number
   }


### PR DESCRIPTION
closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional “Scroll to Top/Bottom” buttons in the question panel with smooth scrolling (enabled by default).
  - New UI setting to show/hide these scroll controls.
  - Scroll position resets to the top when switching questions.
  - Improved per-question image rendering with smarter width scaling for clearer, more consistent image layout.

- Style
  - Updated scrollbar colors in light mode for better contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->