### PR TITLE
feat(results-page): add ability to reevaluate results of a test with different answer key data

### DIFF
--- a/apps/shared/app/components/Cbt/Results/AnswerKeyDialog.vue
+++ b/apps/shared/app/components/Cbt/Results/AnswerKeyDialog.vue
@@ -89,11 +89,17 @@ async function handleFileUpload(file: File) {
       if ('testAnswerKey' in (data.jsonData || {})) {
         emitData(data.jsonData as TestAnswerKeyJsonData)
       }
+      else {
+        useErrorToast('Selected ZIP file does not contain Answer Key data (testAnswerKey).')
+      }
     }
     else {
       const data = await utilParseJsonFile(file)
       if (data?.testAnswerKey) {
         emitData(data)
+      }
+      else {
+        useErrorToast('Selected JSON file does not contain Answer Key data (testAnswerKey).')
       }
     }
   }

--- a/apps/shared/app/components/Cbt/Results/OverviewCard.vue
+++ b/apps/shared/app/components/Cbt/Results/OverviewCard.vue
@@ -110,7 +110,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  menuBtnClick: [buttonEvent: MouseEvent]
+  menuBtnClick: [buttonEvent: MouseEvent, isResultsGenerated: boolean]
   viewResultsBtnClick: [isResultsGenerated: boolean]
 }>()
 
@@ -125,7 +125,7 @@ const isResultsGenerated = computed(() => {
 })
 
 const menuBtnClickHandler = (e: MouseEvent) => {
-  emit('menuBtnClick', e)
+  emit('menuBtnClick', e, isResultsGenerated.value)
 }
 
 const viewResultsBtnClickHandler = () => {

--- a/apps/shared/app/components/Docs/GenerateAnswerKey.vue
+++ b/apps/shared/app/components/Docs/GenerateAnswerKey.vue
@@ -60,20 +60,10 @@
                         Usable on the <strong>Test Interface</strong> and <strong>Test Results</strong> pages.
                       </li>
                       <li>
-                        <strong>JSON file (merged):</strong> A JSON file with answer key data embedded alongside existing data.<br>
-                        Usable on the <strong>Test Interface</strong> and <strong>Test Results</strong> pages.
-                      </li>
-                      <li>
-                        <strong>JSON file (separate):</strong> A JSON file containing only the answer key data.<br>
+                        <strong>JSON file:</strong> A JSON file containing only the answer key data.<br>
                         Usable only on the <strong>Test Results</strong> page.
                       </li>
                     </ul>
-                  </li>
-                  <li>
-                    If you're using a <strong>JSON file</strong> as input, you can choose output as either a <strong>merged JSON</strong> or a <strong>separate JSON</strong> file.
-                  </li>
-                  <li>
-                    If you're <strong>loading input from your local database</strong>, the only available output is a <strong>separate JSON</strong> file.
                   </li>
                 </ul>
               </div>

--- a/apps/shared/app/utils/utilGetQuestionResult.ts
+++ b/apps/shared/app/utils/utilGetQuestionResult.ts
@@ -3,7 +3,7 @@ type ValidQuestionResult = Omit<QuestionResult, 'status'> & { status: ValidQuest
 // function to evaluate a question and return QuestionResult
 export default (
   questionData: TestInterfaceQuestionData,
-  questionCorrectAnswer: TestAnswerKeyData[string][string][string],
+  questionCorrectAnswer: QuestionAnswer,
 ): ValidQuestionResult => {
   const { type, status, answer } = questionData
   const marks = {

--- a/apps/shared/shared/types/index.d.ts
+++ b/apps/shared/shared/types/index.d.ts
@@ -25,7 +25,11 @@ export type QuestionMsmAnswerType = {
 
 export type QuestionAnswer = number | number[] | string | null | QuestionMsmAnswerType | 'BONUS' | 'DROPPED'
 
-export type TestAnswerKeyData = GenericSubjectsTree<QuestionAnswer>
+export type TestAnswerKeyData = GenericSubjectsTree<{
+  type: QuestionType
+  answerOptions?: string
+  correctAnswer: QuestionAnswer
+}>
 
 export interface JsonOutput {
   appVersion: string
@@ -72,19 +76,25 @@ export interface PdfCropperJsonOutput extends JsonOutput {
 export interface AnswerKeyJsonOutputBasedOnPdfCropper
   extends Omit<PdfCropperJsonOutput, 'generatedBy'> {
   generatedBy: 'answerKeyPage'
-  generatedBasedOn: 'pdfCropperPage'
   testAnswerKey: TestAnswerKeyData
 }
 
 export interface AnswerKeyJsonOutputBasedOnTestInterface
   extends Omit<TestInterfaceJsonOutput, 'generatedBy'> {
   generatedBy: 'answerKeyPage'
-  generatedBasedOn: 'testInterfacePage'
+  testAnswerKey: TestAnswerKeyData
+}
+
+export interface AnswerKeyJsonOutputBasedOnTestResult
+  extends Omit<TestResultJsonOutput, 'generatedBy'> {
+  generatedBy: 'answerKeyPage'
   testAnswerKey: TestAnswerKeyData
 }
 
 export type AnswerKeyJsonOutput = AnswerKeyJsonOutputBasedOnPdfCropper
   | AnswerKeyJsonOutputBasedOnTestInterface
+  | AnswerKeyJsonOutputBasedOnTestResult
+  | { generatedBy: 'answerKeyPage', testAnswerKey: TestAnswerKeyData, appVersion: string }
 
 export type QuestionsImageUrls = {
   [queId: number | string]: string[]

--- a/apps/shared/shared/types/pdf-cropper.d.ts
+++ b/apps/shared/shared/types/pdf-cropper.d.ts
@@ -25,7 +25,6 @@ export type PdfCropperSettings = {
     blurIntensity: number
     showQuestionDetailsOnOverlay: boolean
     allowResizingPanels: boolean
-    showInfoTooltipsForPatternMode: boolean
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-evaluate test results by uploading an answer key; dialog and menu action added. 
  * Load test data from the database via test-id (route/query) for quick access.
  * Answer Key download link opens in new tab and includes test id when available.

* **Bug Fixes**
  * Improved file upload validation with user-facing error toasts for invalid/missing data and load failures.

* **Documentation**
  * Consolidated JSON export options into a single "JSON file" output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->