### PR TITLE
feat(pdf-cropper): add ability to enable calculating text character boundaries precisely for pattern cropper in config settings

### DIFF
--- a/apps/shared/app/components/PdfCropper/PatternMode/ConfigForm.vue
+++ b/apps/shared/app/components/PdfCropper/PatternMode/ConfigForm.vue
@@ -8,6 +8,10 @@ import type {
 import {
   getSubjectData,
 } from '#layers/shared/app/src/pdf-cropper-pattern-mode/json-config-to-form-data'
+import {
+  yCoordinateGroupingRangeForLineTooltipContent,
+  calculateCharacterBoundariesPreciselyTooltipContent,
+} from '../tooltipContents'
 
 const { form } = usePatternModeFormData()
 
@@ -212,6 +216,20 @@ function addNewSubjectFromCurrentConfig(subjectIdx: number) {
                 />
               </div>
               <div class="flex items-center gap-3">
+                <IconWithTooltip :content="calculateCharacterBoundariesPreciselyTooltipContent" />
+                <UiLabel
+                  class="text-lg cursor-pointer"
+                  for="accurate-bbox"
+                >
+                  Calculate Character Boundaries Precisely:
+                </UiLabel>
+                <UiSwitch
+                  id="accurate-bbox"
+                  v-model="form!.settings.calculateCharacterBoundariesPrecisely"
+                />
+              </div>
+              <div class="flex items-center gap-3">
+                <IconWithTooltip :content="yCoordinateGroupingRangeForLineTooltipContent" />
                 <UiLabel
                   class="text-lg"
                   for="y-coordinate-grouping-range-switch"

--- a/apps/shared/app/components/PdfCropper/tooltipContents.ts
+++ b/apps/shared/app/components/PdfCropper/tooltipContents.ts
@@ -494,3 +494,45 @@ export const questionsCropWithinTooltipContent = () => h('div', { class: 'space-
     'the header and footer are excluded from being considered in crop related calculations.',
   ]),
 ])
+
+export const yCoordinateGroupingRangeForLineTooltipContent = () => h('div', { class: 'space-y-2' }, [
+  h('p', [
+    'This is the ',
+    h('strong', 'maximum vertical range'),
+    ' (in PDF units) for line grouping.',
+  ]),
+  h('p', [
+    'It specifies how far apart two characters\' Y-midpoints ',
+    '(the average of its top and bottom Y coordinates) can be ',
+    'and still be grouped into the same visual line of text.',
+  ]),
+])
+
+export const calculateCharacterBoundariesPreciselyTooltipContent = () => h('div', { class: 'space-y-2' }, [
+  h('p', [
+    'This option affects how accurately the tool determines the ',
+    h('strong', 'size and position'),
+    ' of every characters.',
+  ]),
+
+  h('ul', { class: 'list-disc space-y-1 ml-6 [&>li]:mb-1' }, [
+    h('li', [
+      h('strong', 'When Enabled (Precise)'),
+      ': The boundaries for each character are calculated ',
+      'very precisely (by analyzing outline of their shape).',
+      h('br'),
+      'High precision can introduce tiny vertical offsets that may ',
+      'cause characters to be incorrectly separated into different lines ',
+      'if your Y-coordinate grouping range is set too low.',
+      h('br'),
+      'Use this only when lines are too close to each other.',
+    ]),
+    h('li', [
+      h('strong', 'When Disabled (Faster)'),
+      ': The boundaries are calculated using a faster, simpler method ',
+      'and usually provides better line grouping.',
+      h('br'),
+      'This is recommended unless lines in your pdf are too close to each other.',
+    ]),
+  ]),
+])

--- a/apps/shared/app/src/pdf-cropper-pattern-mode/config-schema.ts
+++ b/apps/shared/app/src/pdf-cropper-pattern-mode/config-schema.ts
@@ -277,6 +277,7 @@ const subjectSchema = z.union([
 const settingsSchema = z.strictObject({
   yCoordinateGroupingRangeForLine: z.number().nonnegative(),
   ignoreElementsGoingOutsidePage: z.boolean(),
+  calculateCharacterBoundariesPrecisely: z.boolean().optional(),
   linesToIgnore: z.array(regexOrTextPatternSchema).optional(),
 })
 

--- a/apps/shared/app/src/pdf-cropper-pattern-mode/json-config-to-form-data.ts
+++ b/apps/shared/app/src/pdf-cropper-pattern-mode/json-config-to-form-data.ts
@@ -227,6 +227,7 @@ export function getConfigFormDataFromJson(patternModeConfig: PatternModeConfigJs
   return {
     settings: {
       ...settings,
+      calculateCharacterBoundariesPrecisely: !!settings.calculateCharacterBoundariesPrecisely,
       linesToIgnore,
     },
     subjects: getSubjectsData(subjects),

--- a/apps/shared/app/src/worker/mupdf.worker.ts
+++ b/apps/shared/app/src/worker/mupdf.worker.ts
@@ -46,7 +46,7 @@ export class MuPdfProcessor {
           break
         }
         catch (err) {
-          console.error(`Error importing mupdf from url No. ${i + 1}:`, err)
+          console.error(`Error importing mupdf from url no. ${i + 1}:`, err)
         }
       }
     }
@@ -114,6 +114,18 @@ export class MuPdfProcessor {
       }
     }
 
+    const sTextBaseOptions = [
+      'preserve-images',
+      'vectors',
+      'ignore-actualtext',
+      'clip',
+      'accurate-bbox',
+    ]
+    if (!settings.calculateCharacterBoundariesPrecisely)
+      sTextBaseOptions.pop()
+
+    const sTextBaseOptionsStr = sTextBaseOptions.join(',')
+
     const pdfPagesPatternModeData: PdfPagesPatternModeData = {}
     for (const pageNum of pageNums) {
       const page = this.doc.loadPage(pageNum - 1)
@@ -121,15 +133,10 @@ export class MuPdfProcessor {
       const pageWidth = Math.abs(pageMaxX - pageMinX)
       const pageHeight = Math.abs(pageMaxY - pageMinY)
 
-      const sTextOptions = [
-        'preserve-images',
-        'vectors',
-        'ignore-actualtext',
-        `clip-rect=${pageMinX}:${pageMinY}:${pageMaxX}:${pageMaxY}`,
-        'clip',
-      ] as const
+      const sTextOptionsStr = sTextBaseOptionsStr
+        + `,clip-rect=${pageMinX}:${pageMinY}:${pageMaxX}:${pageMaxY}`
 
-      const sText = page.toStructuredText(sTextOptions.join(','))
+      const sText = page.toStructuredText(sTextOptionsStr)
 
       const pageChars: PageTextChar[] = []
       const pageImagesAreaCoords: PdfPagesPatternModeData[number]['images'] = []

--- a/schema/pattern-cropper-config/v1.json
+++ b/schema/pattern-cropper-config/v1.json
@@ -15,6 +15,9 @@
             "ignoreElementsGoingOutsidePage": {
               "type": "boolean"
             },
+            "calculateCharacterBoundariesPrecisely": {
+              "type": "boolean"
+            },
             "linesToIgnore": {
               "type": "array",
               "items": {
@@ -533,7 +536,7 @@
                           "questionRange": {
                             "type": "string",
                             "minLength": 3,
-                            "pattern": "^(?<min>\\d+)\\s{0,3}-\\s{0,3}(?<max>\\d+)$"
+                            "pattern": "^(?<start>\\d+)\\s{0,3}-\\s{0,3}(?<end>\\d+)$"
                           },
                           "suffix": {
                             "type": "string"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Calculate Character Boundaries Precisely" setting with tooltip.
  * Added/expanded tooltip explaining Y coordinate grouping for line detection.

* **Refactor**
  * Streamlined PDF text extraction option handling to honor the new setting and simplify per-page processing.

* **Schema**
  * Public configuration schema updated to include the new boolean setting and refined pattern naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->