### PR TITLE
perf(mupdf-worker): transfer image buffers via comlink, add destroy cleanup, reduce memory usage

### DIFF
--- a/apps/shared/app/components/Cbt/Maker/PdfCropper/index.vue
+++ b/apps/shared/app/components/Cbt/Maker/PdfCropper/index.vue
@@ -496,7 +496,8 @@ async function renderPage(pageNum: number) {
         URL.revokeObjectURL(maybeExistingPage.url)
       }
 
-      const pageImgBlob = await mupdfWorker.getPageImage(pageNum, pageScale, true)
+      const pageImgBuffer = await mupdfWorker.getPageImage(pageNum, pageScale, true)
+      const pageImgBlob = new Blob([pageImgBuffer], { type: 'image/png' })
 
       const pageData = pagesImgData[pageNum]!
       pageData.url = URL.createObjectURL(pageImgBlob)

--- a/apps/shared/app/components/Cbt/Results/QuestionPanel.vue
+++ b/apps/shared/app/components/Cbt/Results/QuestionPanel.vue
@@ -1129,9 +1129,9 @@ async function renderPdftoImgs(questionsPdfData: QuestionsPdfData) {
 
     mupdfOgWorker.onmessage = (e) => {
       if (e.data.type === 'question-image') {
-        const { queId, blob } = e.data as { queId: number, blob: Blob }
+        const { queId, imgBuffer } = e.data as { queId: number, imgBuffer: ArrayBuffer }
 
-        const imgUrl = URL.createObjectURL(blob)
+        const imgUrl = URL.createObjectURL(new Blob([imgBuffer], { type: 'image/png' }))
         testQuestionsImgUrls.value[testId]![queId] ??= []
         testQuestionsImgUrls.value[testId]![queId].push(imgUrl)
       }

--- a/apps/shared/app/components/GenerateTestImages.vue
+++ b/apps/shared/app/components/GenerateTestImages.vue
@@ -100,11 +100,24 @@ async function generateQuestionImages() {
   const processedCropperData = processCropperData(cropperData)
   const scale = pdfState.scale
 
-  const questionsBlobs = await mupdfWorker.generateQuestionImages(
+  const questionImgBuffers = await mupdfWorker.generateQuestionImages(
     processedCropperData,
     scale,
     true,
   )
+
+  const questionsBlobs: TestImageBlobs = {}
+  for (const [section, qImgsObj] of Object.entries(questionImgBuffers)) {
+    questionsBlobs[section] ??= {}
+
+    for (const [question, buffers] of Object.entries(qImgsObj)) {
+      for (const buff of buffers) {
+        const blob = new Blob([buff], { type: 'image/png' })
+        questionsBlobs[section][question] ??= []
+        questionsBlobs[section][question].push(blob)
+      }
+    }
+  }
 
   mupdfWorker.close()
 

--- a/apps/shared/app/src/worker/mupdf.worker.ts
+++ b/apps/shared/app/src/worker/mupdf.worker.ts
@@ -1,4 +1,7 @@
-import { expose as comlinkExpose } from 'comlink'
+import {
+  expose as comlinkExpose,
+  transfer as comlinkTransfer,
+} from 'comlink'
 import type * as Mupdf from 'mupdf'
 import utilRange from '#layers/shared/app/utils/utilRange'
 import type {
@@ -160,6 +163,7 @@ export class MuPdfProcessor {
             pageVectorsAreaCoords.push(coords)
         },
       })
+      sText.destroy()
       page.destroy()
 
       const linesGroupedByY = pageChars.reduce(
@@ -228,6 +232,7 @@ export class MuPdfProcessor {
       transparent,
       true,
     )
+    page.destroy()
     return pixmap
   }
 
@@ -254,6 +259,8 @@ export class MuPdfProcessor {
         pageScale: 1,
       }
       top += height
+
+      page.destroy()
     }
 
     return pagesImgData
@@ -263,12 +270,18 @@ export class MuPdfProcessor {
     pageNum: number,
     scale: number,
     transparent: boolean = false,
-  ): Promise<Blob> {
+  ): Promise<ArrayBuffer> {
     if (!this.doc) throw new Error('PDF not loaded')
 
     const pixmap = await this.getPagePixmap(pageNum, scale, transparent)
 
-    return new Blob([pixmap.asPNG() as Uint8Array<ArrayBuffer>], { type: 'image/png' })
+    try {
+      const png = pixmap.asPNG() as Uint8Array<ArrayBuffer>
+      return comlinkTransfer(png.buffer, [png.buffer])
+    }
+    finally {
+      pixmap.destroy()
+    }
   }
 
   async generateQuestionImages(
@@ -279,34 +292,43 @@ export class MuPdfProcessor {
     if (!this.doc) throw new Error('PDF not loaded')
 
     let progressCount = 0
-    const imageBlobs: TestImageBlobs = {}
+    const sectionQImageBuffers: {
+      [section: string]: { [question: string | number]: ArrayBuffer[] }
+    } = {}
+    const images = new Set<ArrayBuffer>()
 
     for (const pageKey of Object.keys(processedCropperData)) {
-      const pageNum = parseInt(pageKey)
-      const pagePixmap = await this.getPagePixmap(pageNum, scale, transparent)
+      let pagePixmap: Mupdf.Pixmap | null = null
+      try {
+        const pageNum = parseInt(pageKey)
+        pagePixmap = await this.getPagePixmap(pageNum, scale, transparent)
+        const pageProcessedData = processedCropperData[pageKey]
 
-      const pageProcessedData = processedCropperData[pageKey]
+        if (!pageProcessedData) continue
 
-      if (!pageProcessedData) continue
+        for (const questionData of pageProcessedData) {
+          const { pdfData, section, question } = questionData
 
-      for (const questionData of pageProcessedData) {
-        const { pdfData, section, question } = questionData
+          if (!sectionQImageBuffers[section]?.[question]) {
+            progressCount++
+            self.postMessage({ type: 'progress', value: progressCount })
+          }
+          const buff = await this.getCroppedImg(pagePixmap, pdfData)
+          if (buff) {
+            sectionQImageBuffers[section] ??= {}
+            sectionQImageBuffers[section][question] ??= []
 
-        if (!imageBlobs[section]?.[question]) {
-          progressCount++
-          self.postMessage({ type: 'progress', value: progressCount })
+            sectionQImageBuffers[section][question].push(buff)
+            images.add(buff)
+          }
         }
-        const blob = await this.getCroppedImg(pagePixmap, pdfData)
-        if (blob) {
-          imageBlobs[section] ??= {}
-          imageBlobs[section][question] ??= []
-
-          imageBlobs[section][question].push(blob)
-        }
+      }
+      finally {
+        pagePixmap?.destroy()
       }
     }
 
-    return imageBlobs
+    return comlinkTransfer(sectionQImageBuffers, [...images])
   }
 
   async generateAndPostQuestionImagesIndividually(
@@ -326,22 +348,27 @@ export class MuPdfProcessor {
 
         pagePixmaps[pageNum] ??= await this.getPagePixmap(Number(pageNum), scale, transparent)
 
-        const imgBlob = await this.getCroppedImg(pagePixmaps[pageNum], pdfDataItem)
+        const imgBuffer = await this.getCroppedImg(pagePixmaps[pageNum], pdfDataItem)
         self.postMessage(
           {
             type: 'question-image',
             queId,
-            blob: imgBlob,
+            imgBuffer,
           },
+          [imgBuffer],
         )
       }
+    }
+
+    for (const pixmap of Object.values(pagePixmaps)) {
+      pixmap.destroy()
     }
   }
 
   private async getCroppedImg(pagePixmap: Mupdf.Pixmap, pdfData: PdfData) {
     const { x, y, w, h } = pdfData
 
-    const croppedPNG = pagePixmap.warp(
+    const croppedPixmap = pagePixmap.warp(
       [
         [x, y],
         [x + w, y],
@@ -350,9 +377,11 @@ export class MuPdfProcessor {
       ],
       w,
       h,
-    ).asPNG()
+    )
+    const png = croppedPixmap.asPNG() as Uint8Array<ArrayBuffer>
+    croppedPixmap.destroy()
 
-    return new Blob([croppedPNG as Uint8Array<ArrayBuffer>], { type: 'image/png' })
+    return png.buffer
   }
 
   close() {


### PR DESCRIPTION
This resolves a memory leak in the worker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced internal image processing architecture across PDF cropping, question panel display, and test image generation components to improve data handling consistency and overall system reliability.
  * Strengthened and implemented comprehensive resource cleanup during image operations to optimize memory management and ensure stable application performance under various operating conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->