### PR TITLE
feat(test-maker): prevent accidental unload or page navigation during test creation

### DIFF
--- a/apps/shared/app/pages/cbt/maker.vue
+++ b/apps/shared/app/pages/cbt/maker.vue
@@ -151,6 +151,39 @@ const downloadData = computed(() => {
   }
 })
 
+function onBeforeUnloadCallback(e: Event) {
+  e.preventDefault()
+}
+
+let removeNagivationGuard = () => {}
+
+watch(() => pdfLoadingState.isLoaded,
+  () => {
+    window.addEventListener('beforeunload', onBeforeUnloadCallback)
+    const router = useRouter()
+    removeNagivationGuard = router.beforeEach((_, __, next) => {
+      const confirmLeave = confirm(
+        'Are you sure you want to leave Test Maker?\n'
+        + 'Current test making progress may be lost if not saved/downloaded!',
+      )
+      if (confirmLeave) {
+        next()
+      }
+      else {
+        next(false)
+      }
+    })
+  },
+  { once: true },
+)
+
+const pageCleanUpCallback = () => {
+  window.removeEventListener('beforeunload', onBeforeUnloadCallback)
+  removeNagivationGuard()
+}
+
+onBeforeUnmount(pageCleanUpCallback)
+
 provide(outputZipFileNameKey, outputZipFileName)
 provide(downloadDataKey, downloadData)
 provide(testConfigKey, testConfig)


### PR DESCRIPTION
resolves #346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation prompt when leaving the Test Maker page while a PDF file is loaded, allowing users to cancel the navigation if needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TheMoonVyy/pdf2cbt/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->