### PR TITLE
fix(updates-page): watch version query param changes

### DIFF
--- a/apps/shared/app/pages/updates.vue
+++ b/apps/shared/app/pages/updates.vue
@@ -249,30 +249,40 @@ async function selectReleasesSubMenu(version?: string) {
 
 onMounted(() => {
   const route = useRoute()
-  // Prefer version param if both exist
-  const versionParam = route.query.release
-    || route.query.version
-    || route.query.v
 
-  if (versionParam && typeof versionParam === 'string') {
-    const match = versionParam.match(versionRegex)
-    if (match) {
-      const version = `${match[1]}.${match[2]}.${match[3]}`
-      if (releasesData.has(version)) {
-        selectedMenu.value = 'releases'
-        selectReleasesSubMenu(version)
+  watch(
+    () => route.query,
+    () => {
+      for (const key of ['release', 'version', 'v']) {
+        const param = route.query[key]
+        if (!param) continue
+
+        const value = Array.isArray(param) ? param[0] : param
+        if (!value) continue
+
+        const match = value.match(versionRegex)
+        if (!match) break
+
+        const version = `${match[1]}.${match[2]}.${match[3]}`
+        if (releasesData.has(version)) {
+          selectedMenu.value = 'releases'
+          selectReleasesSubMenu(version)
+          return
+        }
+
+        break
+      }
+
+      const devFlag = 'dev' in route.query
+      if (devFlag) {
+        selectMenu('dev')
         return
       }
-    }
-  }
 
-  const devFlag = 'dev' in route.query
-  if (devFlag) {
-    selectMenu('dev')
-    return
-  }
-
-  selectMenu('releases')
+      selectMenu('releases')
+    },
+    { immediate: true, deep: true },
+  )
 })
 </script>
 


### PR DESCRIPTION
The updates page only checked the version query parameter during component mount.

In production, the query parameter can become available after the initial render, causing the requested release to be ignored and the latest release to be shown instead. Watch the version query parameter so the correct release is selected whenever it becomes available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-page navigation when query parameters change.
  * Added support for release, version, and abbreviated version links, including array-form values.
  * Invalid or missing versions now reliably fall back to the releases view, while development links continue to open the appropriate section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->